### PR TITLE
Export SupportedLanguage

### DIFF
--- a/i18n/bundle/bundle.go
+++ b/i18n/bundle/bundle.go
@@ -137,15 +137,7 @@ func (b *Bundle) MustTfunc(languageSource string, languageSources ...string) Tra
 //
 // It can parse languages from Accept-Language headers (RFC 2616).
 func (b *Bundle) Tfunc(src string, srcs ...string) (TranslateFunc, error) {
-	lang := b.translatedLanguage(src)
-	if lang == nil {
-		for _, src := range srcs {
-			lang = b.translatedLanguage(src)
-			if lang != nil {
-				break
-			}
-		}
-	}
+	lang := b.SupportedLanguage(src, srcs...)
 	var err error
 	if lang == nil {
 		err = fmt.Errorf("no supported languages found %#v", append(srcs, src))
@@ -163,6 +155,23 @@ func (b *Bundle) translatedLanguage(src string) *language.Language {
 		}
 	}
 	return nil
+}
+
+// SupportedLanguage returns the first language which
+// has a non-zero number of translations in the bundle.
+//
+// It can parse languages from Accept-Language headers (RFC 2616).
+func (b *Bundle) SupportedLanguage(src string, srcs ...string) *language.Language {
+	lang := b.translatedLanguage(src)
+	if lang == nil {
+		for _, src := range srcs {
+			lang = b.translatedLanguage(src)
+			if lang != nil {
+				break
+			}
+		}
+	}
+	return lang
 }
 
 func (b *Bundle) translate(lang *language.Language, translationID string, args ...interface{}) string {

--- a/i18n/bundle/bundle_test.go
+++ b/i18n/bundle/bundle_test.go
@@ -116,10 +116,9 @@ func TestTfunc(t *testing.T) {
 			t.Errorf("translation %d was %s; expected %s", i, result, test.result)
 		}
 		lang := b.SupportedLanguage(test.languageIDs[0], test.languageIDs[1:]...)
-		if ((test.expectedLanguage == nil) && (lang == nil)) ||
-			(lang.String() == test.expectedLanguage.String()) {
-			// ok
-		} else {
+		if (lang == nil && test.expectedLanguage != nil) ||
+			(lang != nil && test.expectedLanguage == nil) ||
+			(lang != nil && test.expectedLanguage != nil && lang.String() != test.expectedLanguage.String()) {
 			t.Errorf("lang %d was %s; expected %s", i, lang, test.expectedLanguage)
 		}
 	}

--- a/i18n/bundle/bundle_test.go
+++ b/i18n/bundle/bundle_test.go
@@ -36,60 +36,71 @@ func TestTfunc(t *testing.T) {
 	b := New()
 	translationID := "translation_id"
 	englishTranslation := "en-US(translation_id)"
-	b.AddTranslation(language.MustParse("en-US")[0], testNewTranslation(t, map[string]interface{}{
+	englishLanguage := language.MustParse("en-US")[0]
+	frenchLanguage := language.MustParse("fr-FR")[0]
+	spanishLanguage := language.MustParse("es")[0]
+	b.AddTranslation(englishLanguage, testNewTranslation(t, map[string]interface{}{
 		"id":          translationID,
 		"translation": englishTranslation,
 	}))
 	frenchTranslation := "fr-FR(translation_id)"
-	b.AddTranslation(language.MustParse("fr-FR")[0], testNewTranslation(t, map[string]interface{}{
+	b.AddTranslation(frenchLanguage, testNewTranslation(t, map[string]interface{}{
 		"id":          translationID,
 		"translation": frenchTranslation,
 	}))
 	spanishTranslation := "es(translation_id)"
-	b.AddTranslation(language.MustParse("es")[0], testNewTranslation(t, map[string]interface{}{
+	b.AddTranslation(spanishLanguage, testNewTranslation(t, map[string]interface{}{
 		"id":          translationID,
 		"translation": spanishTranslation,
 	}))
 
 	tests := []struct {
-		languageIDs []string
-		valid       bool
-		result      string
+		languageIDs      []string
+		valid            bool
+		result           string
+		expectedLanguage *language.Language
 	}{
 		{
 			[]string{"invalid"},
 			false,
 			translationID,
+			nil,
 		},
 		{
 			[]string{"invalid", "invalid2"},
 			false,
 			translationID,
+			nil,
 		},
 		{
 			[]string{"invalid", "en-US"},
 			true,
 			englishTranslation,
+			englishLanguage,
 		},
 		{
 			[]string{"en-US", "invalid"},
 			true,
 			englishTranslation,
+			englishLanguage,
 		},
 		{
 			[]string{"en-US", "fr-FR"},
 			true,
 			englishTranslation,
+			englishLanguage,
 		},
 		{
 			[]string{"invalid", "es"},
 			true,
 			spanishTranslation,
+			spanishLanguage,
 		},
 		{
 			[]string{"zh-CN,fr-XX,es"},
 			true,
 			spanishTranslation,
+			spanishLanguage,
 		},
 	}
 
@@ -103,6 +114,13 @@ func TestTfunc(t *testing.T) {
 		}
 		if result := tf(translationID); result != test.result {
 			t.Errorf("translation %d was %s; expected %s", i, result, test.result)
+		}
+		lang := b.SupportedLanguage(test.languageIDs[0], test.languageIDs[1:]...)
+		if ((test.expectedLanguage == nil) && (lang == nil)) ||
+			(lang.String() == test.expectedLanguage.String()) {
+			// ok
+		} else {
+			t.Errorf("lang %d was %s; expected %s", i, lang, test.expectedLanguage)
 		}
 	}
 }

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -126,3 +126,11 @@ func Tfunc(languageSource string, languageSources ...string) (TranslateFunc, err
 	tf, err := defaultBundle.Tfunc(languageSource, languageSources...)
 	return TranslateFunc(tf), err
 }
+
+// SupportedLanguage returns the first language which
+// has a non-zero number of translations.
+//
+// It can parse languages from Accept-Language headers (RFC 2616).
+func SupportedLanguage(languageSource string, languageSources ...string) *language.Language {
+	return defaultBundle.SupportedLanguage(languageSource, languageSources...)
+}

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -127,6 +127,19 @@ func Tfunc(languageSource string, languageSources ...string) (TranslateFunc, err
 	return TranslateFunc(tf), err
 }
 
+// MustTfuncAndLanguage returns both Tfunc and SupportedLanguage at once.
+// This panics if an error happens.
+func MustTfuncAndLanguage(languageSource string, languageSources ...string) (TranslateFunc, *language.Language) {
+	tfunc, lang := defaultBundle.MustTfuncAndLanguage(languageSource, languageSources...)
+	return TranslateFunc(tfunc), lang
+}
+
+// TfuncAndLanguage returns both Tfunc and SupportedLanguage at once.
+func TfuncAndLanguage(languageSource string, languageSources ...string) (TranslateFunc, *language.Language, error) {
+	tf, lang, err := defaultBundle.TfuncAndLanguage(languageSource, languageSources...)
+	return TranslateFunc(tf), lang, err
+}
+
 // SupportedLanguage returns the first language which
 // has a non-zero number of translations.
 //


### PR DESCRIPTION
I'd like to know which language go-i18n decided to use among the candidates caller provided to Tfunc, for example save the language into database for pushing localized content afterwards.
