### PR TITLE
bundle: runtime-reflect structs to map[string]interface{}

### DIFF
--- a/i18n/bundle/bundle.go
+++ b/i18n/bundle/bundle.go
@@ -10,6 +10,7 @@ import (
 
 	"path/filepath"
 
+	"github.com/fatih/structs"
 	"github.com/nicksnyder/go-i18n/i18n/language"
 	"github.com/nicksnyder/go-i18n/i18n/translation"
 )
@@ -237,7 +238,7 @@ func (b *Bundle) translate(lang *language.Language, translationID string, args .
 
 	var data map[string]interface{}
 	if len(args) > 0 {
-		data, _ = args[0].(map[string]interface{})
+		data = toMap(args[0])
 	}
 
 	if isNumber(count) {
@@ -261,4 +262,13 @@ func isNumber(n interface{}) bool {
 		return true
 	}
 	return false
+}
+
+func toMap(input interface{}) (data map[string]interface{}) {
+	if structs.IsStruct(input) {
+		data = structs.Map(input)
+	} else {
+		data, _ = input.(map[string]interface{})
+	}
+	return
 }

--- a/i18n/bundle/bundle.go
+++ b/i18n/bundle/bundle.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"reflect"
 
 	//	"launchpad.net/goyaml"
 
 	"path/filepath"
 
-	"github.com/fatih/structs"
 	"github.com/nicksnyder/go-i18n/i18n/language"
 	"github.com/nicksnyder/go-i18n/i18n/translation"
 )
@@ -264,11 +264,17 @@ func isNumber(n interface{}) bool {
 	return false
 }
 
-func toMap(input interface{}) (data map[string]interface{}) {
-	if structs.IsStruct(input) {
-		data = structs.Map(input)
-	} else {
-		data, _ = input.(map[string]interface{})
+func toMap(input interface{}) map[string]interface{} {
+	v := reflect.ValueOf(input)
+	switch v.Kind() {
+	case reflect.Map:
+		data, _ := input.(map[string]interface{})
+		return data
+	case reflect.Ptr:
+		return structToMap(v.Elem())
+	case reflect.Struct:
+		return structToMap(v)
+	default:
+		panic(fmt.Errorf("i18n: cannot handle type %s", v.Kind()))
 	}
-	return
 }

--- a/i18n/bundle/bundle.go
+++ b/i18n/bundle/bundle.go
@@ -271,7 +271,7 @@ func toMap(input interface{}) map[string]interface{} {
 		data, _ := input.(map[string]interface{})
 		return data
 	case reflect.Ptr:
-		return structToMap(v.Elem())
+		return toMap(v.Elem().Interface())
 	case reflect.Struct:
 		return structToMap(v)
 	default:

--- a/i18n/bundle/bundle.go
+++ b/i18n/bundle/bundle.go
@@ -238,7 +238,7 @@ func (b *Bundle) translate(lang *language.Language, translationID string, args .
 
 	var data map[string]interface{}
 	if len(args) > 0 {
-		data = toMap(args[0])
+		data, _ = toMap(args[0])
 	}
 
 	if isNumber(count) {
@@ -264,17 +264,17 @@ func isNumber(n interface{}) bool {
 	return false
 }
 
-func toMap(input interface{}) map[string]interface{} {
+func toMap(input interface{}) (map[string]interface{}, error) {
 	v := reflect.ValueOf(input)
 	switch v.Kind() {
 	case reflect.Map:
 		data, _ := input.(map[string]interface{})
-		return data
+		return data, nil
 	case reflect.Ptr:
 		return toMap(v.Elem().Interface())
 	case reflect.Struct:
 		return structToMap(v)
 	default:
-		panic(fmt.Errorf("i18n: cannot handle type %s", v.Kind()))
+		return nil, fmt.Errorf("i18n: cannot handle type %s", v.Kind())
 	}
 }

--- a/i18n/bundle/bundle_test.go
+++ b/i18n/bundle/bundle_test.go
@@ -183,3 +183,29 @@ func TestToMapWithMap(t *testing.T) {
 		}
 	}
 }
+
+func TestTranslate(t *testing.T) {
+	b := New()
+	translationID := "translation_id"
+	englishLanguage := languageWithTag("en-US")
+	b.AddTranslation(englishLanguage, testNewTranslation(t, map[string]interface{}{
+		"id":          translationID,
+		"translation": "{{.Person}} is {{.Age}} years old.",
+	}))
+	input := struct {
+		Person string
+		Age    int
+	}{
+		Person: "Bob",
+		Age:    26,
+	}
+	expected := "Bob is 26 years old."
+
+	tf, err := b.Tfunc("en-US")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if result := tf("translation_id", input); result != expected {
+		t.Errorf("expected '%s', got: '%s'", expected, result)
+	}
+}

--- a/i18n/bundle/bundle_test.go
+++ b/i18n/bundle/bundle_test.go
@@ -133,9 +133,9 @@ func TestTfuncAndLanguage(t *testing.T) {
 }
 
 func TestToMap(t *testing.T) {
-	testMatchesMap(t, "with map", testMap, toMap(testMap))
-	testMatchesMap(t, "with struct", testMap, toMap(testStruct))
-	testMatchesMap(t, "with pointer", testMap, toMap(&testStruct))
+	testToMatchesMap(t, "with map", testMap, testMap)
+	testToMatchesMap(t, "with struct", testMap, testStruct)
+	testToMatchesMap(t, "with pointer", testMap, &testStruct)
 }
 
 func TestTranslate(t *testing.T) {
@@ -181,6 +181,14 @@ func testNewTranslation(t *testing.T, data map[string]interface{}) translation.T
 
 func languageWithTag(tag string) *language.Language {
 	return language.MustParse(tag)[0]
+}
+
+func testToMatchesMap(t *testing.T, key string, expected map[string]interface{}, input interface{}) {
+	actual, err := toMap(input)
+	if err != nil {
+		t.Errorf("toMap failed with (%s)")
+	}
+	testMatchesMap(t, key, expected, actual)
 }
 
 func testMatchesMap(t *testing.T, key string, expected map[string]interface{}, actual map[string]interface{}) {

--- a/i18n/bundle/bundle_test.go
+++ b/i18n/bundle/bundle_test.go
@@ -156,3 +156,30 @@ func testNewTranslation(t *testing.T, data map[string]interface{}) translation.T
 func languageWithTag(tag string) *language.Language {
 	return language.MustParse(tag)[0]
 }
+
+func TestToMapWithMap(t *testing.T) {
+	masterMap := map[string]interface{}{
+		"Person": "Bob",
+		"Age":    26,
+	}
+
+	data := toMap(masterMap)
+	for k, v := range masterMap {
+		if data[k] != v {
+			t.Errorf("expected %v, got: %v", v, data[k])
+		}
+	}
+
+	data = toMap(struct {
+		Person string
+		Age    int
+	}{
+		Person: "Bob",
+		Age:    26,
+	})
+	for k, v := range masterMap {
+		if data[k] != v {
+			t.Errorf("expected %v, got: %v", v, data[k])
+		}
+	}
+}

--- a/i18n/bundle/bundle_test.go
+++ b/i18n/bundle/bundle_test.go
@@ -138,6 +138,18 @@ func TestToMap(t *testing.T) {
 	testToMatchesMap(t, "with pointer", testMap, &testStruct)
 }
 
+func BenchmarkToMapWithMap(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		toMap(testMap)
+	}
+}
+
+func BenchmarkToMapWithStruct(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		toMap(testStruct)
+	}
+}
+
 func TestTranslate(t *testing.T) {
 	b := New()
 	lang := "en-US"

--- a/i18n/bundle/structs.go
+++ b/i18n/bundle/structs.go
@@ -1,0 +1,46 @@
+package bundle
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Panic if the value does not represent a struct.
+func assertStruct(v reflect.Value) {
+	if kind := v.Kind(); kind != reflect.Struct {
+		panic(fmt.Errorf("struct expected, got %s", kind))
+	}
+}
+
+// Converts a struct to a map[string]interface{}.
+// Pulled from github.com/fatih/structs, modified to omit tagging and
+// nested conversion.
+func structToMap(v reflect.Value) map[string]interface{} {
+	assertStruct(v)
+
+	out := make(map[string]interface{})
+	fields := structFieldNames(v)
+	for _, field := range fields {
+		out[field] = v.FieldByName(field).Interface()
+	}
+	return out
+}
+
+// Creates a slice of the struct's field names.
+// Pulled from github.com/fatih/structs, modified to omit tagging and to
+// only return the field name rather than the full reflect.StructField.
+func structFieldNames(v reflect.Value) []string {
+	assertStruct(v)
+
+	var fields []string
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		// unexported field. skip.
+		if field.PkgPath != "" {
+			continue
+		}
+		fields = append(fields, field.Name)
+	}
+	return fields
+}

--- a/i18n/bundle/structs.go
+++ b/i18n/bundle/structs.go
@@ -6,31 +6,36 @@ import (
 )
 
 // Panic if the value does not represent a struct.
-func assertStruct(v reflect.Value) {
-	if kind := v.Kind(); kind != reflect.Struct {
-		panic(fmt.Errorf("struct expected, got %s", kind))
-	}
+func isStruct(v reflect.Value) bool {
+	return v.Kind() == reflect.Struct
 }
 
 // Converts a struct to a map[string]interface{}.
 // Pulled from github.com/fatih/structs, modified to omit tagging and
 // nested conversion.
-func structToMap(v reflect.Value) map[string]interface{} {
-	assertStruct(v)
+func structToMap(v reflect.Value) (map[string]interface{}, error) {
+	if !isStruct(v) {
+		return nil, fmt.Errorf("struct expected, got %s", v.Kind())
+	}
 
 	out := make(map[string]interface{})
-	fields := structFieldNames(v)
+	fields, err := structFieldNames(v)
+	if err != nil {
+		return nil, err
+	}
 	for _, field := range fields {
 		out[field] = v.FieldByName(field).Interface()
 	}
-	return out
+	return out, nil
 }
 
 // Creates a slice of the struct's field names.
 // Pulled from github.com/fatih/structs, modified to omit tagging and to
 // only return the field name rather than the full reflect.StructField.
-func structFieldNames(v reflect.Value) []string {
-	assertStruct(v)
+func structFieldNames(v reflect.Value) ([]string, error) {
+	if !isStruct(v) {
+		return nil, fmt.Errorf("struct expected, got %s", v.Kind())
+	}
 
 	var fields []string
 	t := v.Type()
@@ -42,5 +47,5 @@ func structFieldNames(v reflect.Value) []string {
 		}
 		fields = append(fields, field.Name)
 	}
-	return fields
+	return fields, nil
 }

--- a/i18n/bundle/structs.go
+++ b/i18n/bundle/structs.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-// Panic if the value does not represent a struct.
+// Whether the Value represents a struct value.
 func isStruct(v reflect.Value) bool {
 	return v.Kind() == reflect.Struct
 }

--- a/i18n/bundle/structs_test.go
+++ b/i18n/bundle/structs_test.go
@@ -1,0 +1,58 @@
+package bundle
+
+import (
+	"reflect"
+	"testing"
+)
+
+type testPerson struct {
+	Person string
+	Age    int
+}
+
+var (
+	fieldNames = []string{"Person", "Age"}
+	testMap    = map[string]interface{}{
+		"Person": "Bob",
+		"Age":    26,
+	}
+	testStruct = testPerson{Person: "Bob", Age: 26}
+	testValue  = reflect.ValueOf(testStruct)
+)
+
+func TestStructToMap(t *testing.T) {
+	testMatchesMap(t, "with struct", testMap, structToMap(testValue))
+}
+
+func TestStructToMapPanicsWithNonStruct(t *testing.T) {
+	defer testPanics(t, "struct expected, got ptr")
+	testMatchesMap(t, "with pointer", testMap, structToMap(reflect.ValueOf(&testStruct)))
+}
+
+func TestStructFieldNames(t *testing.T) {
+	fields := structFieldNames(testValue)
+	if !reflect.DeepEqual(fields, fieldNames) {
+		t.Errorf("expected %s, got %s", fieldNames, fields)
+	}
+}
+
+func TestStructFieldNamesPanicsWithNonStruct(t *testing.T) {
+	defer testPanics(t, "struct expected, got ptr")
+	structFieldNames(reflect.ValueOf(&testStruct))
+}
+
+func testPanics(t *testing.T, expected string) {
+	if e := recover(); e != nil {
+		if err, ok := e.(error); ok {
+			if err.Error() != expected {
+				t.Errorf("expected '%s', got '%s'",
+					expected,
+					err.Error())
+			}
+		} else {
+			t.Errorf("expected error, got: %v", e)
+		}
+	} else {
+		t.Errorf("expected error, none found")
+	}
+}

--- a/i18n/bundle/structs_test.go
+++ b/i18n/bundle/structs_test.go
@@ -51,3 +51,17 @@ func TestStructFieldNamesErrorsWithNonStruct(t *testing.T) {
 		t.Errorf("expecting expecting error, got nothing", err)
 	}
 }
+
+func BenchmarkStructToMapWithMap(b *testing.B) {
+	v := reflect.ValueOf(testMap)
+	for i := 0; i < b.N; i++ {
+		structToMap(v)
+	}
+}
+
+func BenchmarkStructToMapWithStruct(b *testing.B) {
+	v := reflect.ValueOf(testStruct)
+	for i := 0; i < b.N; i++ {
+		structToMap(v)
+	}
+}

--- a/i18n/bundle/structs_test.go
+++ b/i18n/bundle/structs_test.go
@@ -21,38 +21,33 @@ var (
 )
 
 func TestStructToMap(t *testing.T) {
-	testMatchesMap(t, "with struct", testMap, structToMap(testValue))
+	actual, err := structToMap(testValue)
+	if err != nil {
+		t.Errorf("not expecting error, got %v", err)
+	}
+	testMatchesMap(t, "with struct", testMap, actual)
 }
 
 func TestStructToMapPanicsWithNonStruct(t *testing.T) {
-	defer testPanics(t, "struct expected, got ptr")
-	testMatchesMap(t, "with pointer", testMap, structToMap(reflect.ValueOf(&testStruct)))
+	_, err := structToMap(reflect.ValueOf(&testStruct))
+	if err == nil {
+		t.Errorf("expecting expecting error, got nothing", err)
+	}
 }
 
 func TestStructFieldNames(t *testing.T) {
-	fields := structFieldNames(testValue)
+	fields, err := structFieldNames(testValue)
+	if err != nil {
+		t.Errorf("not expecting error, got %v", err)
+	}
 	if !reflect.DeepEqual(fields, fieldNames) {
 		t.Errorf("expected %s, got %s", fieldNames, fields)
 	}
 }
 
 func TestStructFieldNamesPanicsWithNonStruct(t *testing.T) {
-	defer testPanics(t, "struct expected, got ptr")
-	structFieldNames(reflect.ValueOf(&testStruct))
-}
-
-func testPanics(t *testing.T, expected string) {
-	if e := recover(); e != nil {
-		if err, ok := e.(error); ok {
-			if err.Error() != expected {
-				t.Errorf("expected '%s', got '%s'",
-					expected,
-					err.Error())
-			}
-		} else {
-			t.Errorf("expected error, got: %v", e)
-		}
-	} else {
-		t.Errorf("expected error, none found")
+	_, err := structFieldNames(reflect.ValueOf(&testStruct))
+	if err == nil {
+		t.Errorf("expecting expecting error, got nothing", err)
 	}
 }

--- a/i18n/bundle/structs_test.go
+++ b/i18n/bundle/structs_test.go
@@ -28,7 +28,7 @@ func TestStructToMap(t *testing.T) {
 	testMatchesMap(t, "with struct", testMap, actual)
 }
 
-func TestStructToMapPanicsWithNonStruct(t *testing.T) {
+func TestStructToMapErrorsWithNonStruct(t *testing.T) {
 	_, err := structToMap(reflect.ValueOf(&testStruct))
 	if err == nil {
 		t.Errorf("expecting expecting error, got nothing", err)
@@ -45,7 +45,7 @@ func TestStructFieldNames(t *testing.T) {
 	}
 }
 
-func TestStructFieldNamesPanicsWithNonStruct(t *testing.T) {
+func TestStructFieldNamesErrorsWithNonStruct(t *testing.T) {
 	_, err := structFieldNames(reflect.ValueOf(&testStruct))
 	if err == nil {
 		t.Errorf("expecting expecting error, got nothing", err)

--- a/i18n/example_test.go
+++ b/i18n/example_test.go
@@ -10,25 +10,22 @@ func Example() {
 
 	T, _ := i18n.Tfunc("en-US")
 
+	bobMap := map[string]interface{}{"Person": "Bob"}
+	bobStruct := struct{ Person string }{Person: "Bob"}
+
 	fmt.Println(T("program_greeting"))
-	fmt.Println(T("person_greeting", map[string]interface{}{
-		"Person": "Bob",
-	}))
+	fmt.Println(T("person_greeting", bobMap))
+	fmt.Println(T("person_greeting", bobStruct))
 
 	fmt.Println(T("your_unread_email_count", 0))
 	fmt.Println(T("your_unread_email_count", 1))
 	fmt.Println(T("your_unread_email_count", 2))
 	fmt.Println(T("my_height_in_meters", "1.7"))
 
-	fmt.Println(T("person_unread_email_count", 0, map[string]interface{}{
-		"Person": "Bob",
-	}))
-	fmt.Println(T("person_unread_email_count", 1, map[string]interface{}{
-		"Person": "Bob",
-	}))
-	fmt.Println(T("person_unread_email_count", 2, map[string]interface{}{
-		"Person": "Bob",
-	}))
+	fmt.Println(T("person_unread_email_count", 0, bobMap))
+	fmt.Println(T("person_unread_email_count", 1, bobMap))
+	fmt.Println(T("person_unread_email_count", 2, bobMap))
+	fmt.Println(T("person_unread_email_count", 2, bobStruct))
 
 	fmt.Println(T("person_unread_email_count_timeframe", 3, map[string]interface{}{
 		"Person":    "Bob",
@@ -46,12 +43,14 @@ func Example() {
 	// Output:
 	// Hello world
 	// Hello Bob
+	// Hello Bob
 	// You have 0 unread emails.
 	// You have 1 unread email.
 	// You have 2 unread emails.
 	// I am 1.7 meters tall.
 	// Bob has 0 unread emails.
 	// Bob has 1 unread email.
+	// Bob has 2 unread emails.
 	// Bob has 2 unread emails.
 	// Bob has 3 unread emails in the past 0 days.
 	// Bob has 3 unread emails in the past 1 day.

--- a/i18n/exampletemplate_test.go
+++ b/i18n/exampletemplate_test.go
@@ -34,7 +34,24 @@ func Example_template() {
 		"Timeframe": T("d_days", 1),
 	})
 
+	tmpl.Execute(os.Stdout, struct {
+		Person    string
+		Timeframe string
+	}{
+		Person:    "Bob",
+		Timeframe: T("d_days", 1),
+	})
+
 	// Output:
+	// Hello world
+	// Hello Bob
+	// You have 0 unread emails.
+	// You have 1 unread email.
+	// You have 2 unread emails.
+	// Bob has 0 unread emails.
+	// Bob has 1 unread email.
+	// Bob has 2 unread emails.
+	//
 	// Hello world
 	// Hello Bob
 	// You have 0 unread emails.

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -64,11 +64,11 @@ import (
 // TranslateFunc returns the translation of the string identified by translationID.
 //
 // If translationID is a non-plural form, then the first variadic argument may be a map[string]interface{}
-// that contains template data.
+// or struct that contains template data.
 //
 // If translationID is a plural form, then the first variadic argument must be an integer type
 // (int, int8, int16, int32, int64) or a float formatted as a string (e.g. "123.45").
-// The second variadic argument may be a map[string]interface{} that contains template data.
+// The second variadic argument may be a map[string]interface{} or struct that contains template data.
 type TranslateFunc func(translationID string, args ...interface{}) string
 
 // IdentityTfunc returns a TranslateFunc that always returns the translationID passed to it.


### PR DESCRIPTION
Fixes #24.

@nicksnyder The `structs` package is quite lightweight. It is also licensed under MIT. I can attempt to extract the `Struct.structFields()` and `Struct.Map()` methods if you would prefer.