### PR TITLE
pluralspec: add 'th' Thai support.

### DIFF
--- a/i18n/language/pluralspec.go
+++ b/i18n/language/pluralspec.go
@@ -363,6 +363,14 @@ var pluralSpecs = map[string]*PluralSpec{
 		},
 	},
 
+	// Thai
+	"th": &PluralSpec{
+		Plurals: newPluralSet(Other),
+		PluralFunc: func(ops *operands) Plural {
+			return Other
+		},
+	},
+
 	// Turkish
 	"tr": &PluralSpec{
 		Plurals: newPluralSet(One, Other),

--- a/i18n/language/pluralspec_test.go
+++ b/i18n/language/pluralspec_test.go
@@ -504,6 +504,25 @@ func TestUkrainian(t *testing.T) {
 	runTests(t, "uk", tests)
 }
 
+func TestThai(t *testing.T) {
+	tests := []pluralTest{
+		{0, Other},
+		{1, Other},
+		{2, Other},
+		{3, Other},
+		{9, Other},
+		{10, Other},
+		{11, Other},
+		{"0.1", Other},
+		{"0.7", Other},
+		{"1.0", Other},
+		{onePlusEpsilon, Other},
+		{"2.0", Other},
+		{"10.0", Other},
+	}
+	runTests(t, "th", tests)
+}
+
 func appendIntTests(tests []pluralTest, from, to int, p Plural) []pluralTest {
 	for i := from; i <= to; i++ {
 		tests = append(tests, pluralTest{i, p})


### PR DESCRIPTION
Looks like it always uses `other`? 
http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html

/cc @sayrer