### PR TITLE
i18n/language: add vietnamese pluralspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Supported languages
 * Tigrinya (`ti`)
 * Turkish (`tr`)
 * Ukrainian (`uk`)
+* Vietnamese (`vi`)
 
 Adding new languages
 --------------------

--- a/goi18n/doc.go
+++ b/goi18n/doc.go
@@ -6,54 +6,54 @@
 // Help documentation:
 //
 //     goi18n formats and merges translation files.
-//     
+//
 //     Usage:
-//     
+//
 //         goi18n [options] [files...]
-//     
+//
 //     Translation files:
-//     
+//
 //         A translation file contains the strings and translations for a single language.
-//     
+//
 //         Translation file names must have a suffix of a supported format (e.g. .json) and
 //         contain a valid language tag as defined by RFC 5646 (e.g. en-us, fr, zh-hant, etc.).
-//     
+//
 //         For each language represented by at least one input translation file, goi18n will produce 2 output files:
-//     
+//
 //             xx-yy.all.format
 //                 This file contains all strings for the language (translated and untranslated).
 //                 Use this file when loading strings at runtime.
-//     
+//
 //             xx-yy.untranslated.format
 //                 This file contains the strings that have not been translated for this language.
 //                 The translations for the strings in this file will be extracted from the source language.
 //                 After they are translated, merge them back into xx-yy.all.format using goi18n.
-//     
+//
 //     Merging:
-//     
+//
 //         goi18n will merge multiple translation files for the same language.
 //         Duplicate translations will be merged into the existing translation.
 //         Non-empty fields in the duplicate translation will overwrite those fields in the existing translation.
 //         Empty fields in the duplicate translation are ignored.
-//     
+//
 //     Adding a new language:
-//     
+//
 //         To produce translation files for a new language, create an empty translation file with the
 //         appropriate name and pass it in to goi18n.
-//     
+//
 //     Options:
-//     
+//
 //         -sourceLanguage tag
 //             goi18n uses the strings from this language to seed the translations for other languages.
 //             Default: en-us
-//     
+//
 //         -outdir directory
 //             goi18n writes the output translation files to this directory.
 //             Default: .
-//     
+//
 //         -format format
 //             goi18n encodes the output translation files in this format.
 //             Supported formats: json
 //             Default: json
-//     
+//
 package main

--- a/i18n/language/pluralspec.go
+++ b/i18n/language/pluralspec.go
@@ -88,7 +88,7 @@ var pluralSpecs = map[string]*PluralSpec{
 			return Other
 		},
 	},
-	
+
 	// Bosnian
 	"bs": &PluralSpec{
 		Plurals: newPluralSet(One, Few, Other),
@@ -365,7 +365,7 @@ var pluralSpecs = map[string]*PluralSpec{
 			return Other
 		},
 	},
-	
+
 	// Serbian
 	"sr": &PluralSpec{
 		Plurals: newPluralSet(One, Few, Other),
@@ -424,7 +424,7 @@ var pluralSpecs = map[string]*PluralSpec{
 			return Other
 		},
 	},
-	
+
 	// Tigrinya
 	"ti": &PluralSpec{
 		Plurals: newPluralSet(One, Other),
@@ -464,6 +464,14 @@ var pluralSpecs = map[string]*PluralSpec{
 				(ops.V == 0 && mod100 >= 11 && mod100 <= 14) {
 				return Many
 			}
+			return Other
+		},
+	},
+
+	// Vietnamese
+	"vi": &PluralSpec{
+		Plurals: newPluralSet(Other),
+		PluralFunc: func(ops *operands) Plural {
 			return Other
 		},
 	},

--- a/i18n/language/pluralspec_test.go
+++ b/i18n/language/pluralspec_test.go
@@ -40,6 +40,8 @@ func TestGetPluralSpec(t *testing.T) {
 		{"bs", pluralSpecs["bs"]},
 		{"sr", pluralSpecs["sr"]},
 		{"ti", pluralSpecs["ti"]},
+		{"vi", pluralSpecs["vi"]},
+		{"vi-VN", pluralSpecs["vi"]},
 		{".en-US..en-US.", nil},
 		{"zh, en-gb;q=0.8, en;q=0.7", nil},
 		{"zh,en-gb;q=0.8,en;q=0.7", nil},
@@ -473,6 +475,12 @@ func TestThai(t *testing.T) {
 	runTests(t, "th", tests)
 }
 
+func TestVietnamese(t *testing.T) {
+	tests := appendIntTests(nil, 0, 10, Other)
+	tests = appendFloatTests(tests, 0, 10, Other)
+	runTests(t, "vi", tests)
+}
+
 func TestTurkish(t *testing.T) {
 	tests := []pluralTest{
 		{0, Other},
@@ -531,9 +539,8 @@ func TestSerbian(t *testing.T) {
 	runTests(t, "sr", tests)
 }
 
-
 func makeCroatianBosnianSerbianTests() []pluralTest {
-		return []pluralTest{
+	return []pluralTest{
 		{1, One},
 		{"0.1", One},
 		{21, One},


### PR DESCRIPTION
Hey, @nicksnyder! Adding Vietnamese (`vi-VN`, `vi`) in here. Used the pluralization rules from here: http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html