### PR TITLE
i18n/language: add Macedonian

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Supported languages
 * Japanese (`ja`)
 * Lithuanian (`lt`)
 * Malay (`ms`)
+* Macedonian (`mk`)
 * Norweigan (`no`)
 * Polish (`pl`)
 * Portuguese (`pt`)

--- a/i18n/language/pluralspec.go
+++ b/i18n/language/pluralspec.go
@@ -302,6 +302,17 @@ var pluralSpecs = map[string]*PluralSpec{
 		},
 	},
 
+	// Macedonian
+	"mk": &PluralSpec{
+		Plurals: newPluralSet(One, Other),
+		PluralFunc: func(ops *operands) Plural {
+			if (ops.V == 0 && ops.I%10 == 1) || ops.F%10 == 1 {
+				return One
+			}
+			return Other
+		},
+	},
+
 	// Norweigan
 	"no": &PluralSpec{
 		Plurals: newPluralSet(One, Other),

--- a/i18n/language/pluralspec_test.go
+++ b/i18n/language/pluralspec_test.go
@@ -42,6 +42,8 @@ func TestGetPluralSpec(t *testing.T) {
 		{"ti", pluralSpecs["ti"]},
 		{"vi", pluralSpecs["vi"]},
 		{"vi-VN", pluralSpecs["vi"]},
+		{"mk", pluralSpecs["mk"]},
+		{"mk-MK", pluralSpecs["mk"]},
 		{".en-US..en-US.", nil},
 		{"zh, en-gb;q=0.8, en;q=0.7", nil},
 		{"zh,en-gb;q=0.8,en;q=0.7", nil},
@@ -378,6 +380,20 @@ func TestPortuguese(t *testing.T) {
 	}
 	tests = appendFloatTests(tests, 0.0, 10.0, Other)
 	runTests(t, "pt", tests)
+}
+
+func TestMacedonian(t *testing.T) {
+	tests := []pluralTest{
+		{0, Other},
+		{1, One},
+		{"1.1", One},
+		{"2.1", One},
+		{onePlusEpsilon, One},
+		{2, Other},
+		{"2.2", Other},
+		{11, One},
+	}
+	runTests(t, "mk", tests)
 }
 
 func TestPortugueseBrazilian(t *testing.T) {


### PR DESCRIPTION
Rules per http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html

- [x] CLDR rules
- [x] Tests