### PR TITLE
i18n/language: add Latvian

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Supported languages
 * Indonesian (`id`)
 * Italian (`it`)
 * Korean (`ko`)
+* Latvian (`lv`)
 * Japanese (`ja`)
 * Lithuanian (`lt`)
 * Malay (`ms`)

--- a/i18n/language/pluralspec.go
+++ b/i18n/language/pluralspec.go
@@ -264,6 +264,26 @@ var pluralSpecs = map[string]*PluralSpec{
 		},
 	},
 
+	// Latvian
+	"lv": &PluralSpec{
+		Plurals: newPluralSet(Zero, One, Other),
+		PluralFunc: func(ops *operands) Plural {
+			nMod10 := math.Mod(ops.N, 10)
+			nMod100 := math.Mod(ops.N, 100)
+			if nMod10 == 0 ||
+				(11 <= nMod100 && nMod100 <= 19) ||
+				(ops.V == 2 && 11 <= ops.F%100 && ops.F%100 <= 19) {
+				return Zero
+			}
+			if (nMod10 == 1 && nMod100 != 11) ||
+				(ops.V == 2 && ops.F%10 == 1 && ops.F%100 != 11) ||
+				(ops.V != 2 && ops.F%10 == 1) {
+				return One
+			}
+			return Other
+		},
+	},
+
 	// Japanese
 	"ja": &PluralSpec{
 		Plurals: newPluralSet(Other),

--- a/i18n/language/pluralspec_test.go
+++ b/i18n/language/pluralspec_test.go
@@ -42,6 +42,8 @@ func TestGetPluralSpec(t *testing.T) {
 		{"ti", pluralSpecs["ti"]},
 		{"vi", pluralSpecs["vi"]},
 		{"vi-VN", pluralSpecs["vi"]},
+		{"lv", pluralSpecs["lv"]},
+		{"lv-LV", pluralSpecs["lv"]},
 		{".en-US..en-US.", nil},
 		{"zh, en-gb;q=0.8, en;q=0.7", nil},
 		{"zh,en-gb;q=0.8,en;q=0.7", nil},
@@ -312,6 +314,27 @@ func TestKorean(t *testing.T) {
 	tests := appendIntTests(nil, 0, 10, Other)
 	tests = appendFloatTests(tests, 0, 10, Other)
 	runTests(t, "ko", tests)
+}
+
+func TestLatvian(t *testing.T) {
+	tests := []pluralTest{
+		{0, Zero},
+		{"0", Zero},
+		{"0.1", One},
+		{1, One},
+		{"1", One},
+		{onePlusEpsilon, One},
+		{"10.0", Zero},
+		{"10.1", One},
+		{"10.2", Other},
+		{21, One},
+	}
+	tests = appendFloatTests(tests, 0.2, 0.9, Other)
+	tests = appendFloatTests(tests, 1.2, 1.9, Other)
+	tests = appendIntTests(tests, 2, 9, Other)
+	tests = appendIntTests(tests, 10, 20, Zero)
+	tests = appendIntTests(tests, 22, 29, Other)
+	runTests(t, "lv", tests)
 }
 
 func TestJapanese(t *testing.T) {


### PR DESCRIPTION
- [x] [Latvian CLDR rules](http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#lv)
- [x] Tests