### PR TITLE
Add LanguageTags and LanguageTranslationIDs functions

### DIFF
--- a/i18n/bundle/bundle.go
+++ b/i18n/bundle/bundle.go
@@ -134,6 +134,24 @@ func (b *Bundle) Translations() map[string]map[string]translation.Translation {
 	return b.translations
 }
 
+// LanguageTags returns the tags of all languages that that have been added.
+func (b *Bundle) LanguageTags() []string {
+	var tags []string
+	for k := range b.translations {
+		tags = append(tags, k)
+	}
+	return tags
+}
+
+// LanguageTranslationIDs returns the ids of all translations that have been added for a given language.
+func (b *Bundle) LanguageTranslationIDs(languageTag string) []string {
+	var ids []string
+	for id := range b.translations[languageTag] {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
 // MustTfunc is similar to Tfunc except it panics if an error happens.
 func (b *Bundle) MustTfunc(pref string, prefs ...string) TranslateFunc {
 	tfunc, err := b.Tfunc(pref, prefs...)

--- a/i18n/bundle/bundle_test.go
+++ b/i18n/bundle/bundle_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"reflect"
+	"sort"
+
 	"github.com/nicksnyder/go-i18n/i18n/language"
 	"github.com/nicksnyder/go-i18n/i18n/translation"
 )
@@ -31,6 +34,31 @@ func TestMustTfunc(t *testing.T) {
 		}
 	}()
 	New().MustTfunc("invalid")
+}
+
+func TestLanguageTagsAndTranslationIDs(t *testing.T) {
+	b := New()
+	translationID := "translation_id"
+	englishLanguage := languageWithTag("en-US")
+	frenchLanguage := languageWithTag("fr-FR")
+	spanishLanguage := languageWithTag("es")
+	addFakeTranslation(t, b, englishLanguage, "English"+translationID)
+	addFakeTranslation(t, b, frenchLanguage, translationID)
+	addFakeTranslation(t, b, spanishLanguage, translationID)
+
+	tags := b.LanguageTags()
+	sort.Strings(tags)
+	compareTo := []string{englishLanguage.Tag, spanishLanguage.Tag, frenchLanguage.Tag}
+	if !reflect.DeepEqual(tags, compareTo) {
+		t.Errorf("LanguageTags() = %#v; expected: %#v", tags, compareTo)
+	}
+
+	ids := b.LanguageTranslationIDs(englishLanguage.Tag)
+	sort.Strings(ids)
+	compareTo = []string{"English" + translationID}
+	if !reflect.DeepEqual(ids, compareTo) {
+		t.Errorf("LanguageTranslationIDs() = %#v; expected: %#v", ids, compareTo)
+	}
 }
 
 func TestTfuncAndLanguage(t *testing.T) {

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -115,6 +115,16 @@ func AddTranslation(lang *language.Language, translations ...translation.Transla
 	defaultBundle.AddTranslation(lang, translations...)
 }
 
+// LanguageTags returns the tags of all languages that have been added.
+func LanguageTags() []string {
+	return defaultBundle.LanguageTags()
+}
+
+// LanguageTranslationIDs returns the ids of all translations that have been added for a given language.
+func LanguageTranslationIDs(languageTag string) []string {
+	return defaultBundle.LanguageTranslationIDs(languageTag)
+}
+
 // MustTfunc is similar to Tfunc except it panics if an error happens.
 func MustTfunc(languageSource string, languageSources ...string) TranslateFunc {
 	return TranslateFunc(defaultBundle.MustTfunc(languageSource, languageSources...))


### PR DESCRIPTION
Functions to return a string array of the loaded language's tags and
also the IDs of the each language's translations. These can be used
for tests and verifications purposes once the languages and translations
have been loaded.