### PR TITLE
added yaml support with tests

### DIFF
--- a/goi18n/doc.go
+++ b/goi18n/doc.go
@@ -53,7 +53,7 @@
 //
 //         -format format
 //             goi18n encodes the output translation files in this format.
-//             Supported formats: json
+//             Supported formats: json, yaml
 //             Default: json
 //
 package main

--- a/goi18n/goi18n.go
+++ b/goi18n/goi18n.go
@@ -55,7 +55,7 @@ Options:
 
     -format format
         goi18n encodes the output translation files in this format.
-        Supported formats: json
+        Supported formats: json, yaml
         Default: json
 
 `)

--- a/goi18n/merge.go
+++ b/goi18n/merge.go
@@ -3,8 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
-	//"launchpad.net/goyaml"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -110,12 +110,10 @@ func newMarshalFunc(format string) (marshalFunc, error) {
 		return func(v interface{}) ([]byte, error) {
 			return json.MarshalIndent(v, "", "  ")
 		}, nil
-		/*
-			case "yaml":
-				return func(v interface{}) ([]byte, error) {
-					return goyaml.Marshal(v)
-				}, nil
-		*/
+	case "yaml":
+		return func(v interface{}) ([]byte, error) {
+			return yaml.Marshal(v)
+		}, nil
 	}
 	return nil, fmt.Errorf("unsupported format: %s\n", format)
 }

--- a/goi18n/merge_test.go
+++ b/goi18n/merge_test.go
@@ -7,8 +7,7 @@ import (
 	"testing"
 )
 
-func TestMergeExecute(t *testing.T) {
-	resetDir(t, "testdata/output")
+func TestMergeExecuteJSON(t *testing.T) {
 	files := []string{
 		"testdata/input/en-us.one.json",
 		"testdata/input/en-us.two.json",
@@ -16,6 +15,22 @@ func TestMergeExecute(t *testing.T) {
 		"testdata/input/ar-ar.one.json",
 		"testdata/input/ar-ar.two.json",
 	}
+	testMergeExecute(t, files)
+}
+
+func TestMergeExecuteYAML(t *testing.T) {
+	files := []string{
+		"testdata/input/yaml/en-us.one.yaml",
+		"testdata/input/yaml/en-us.two.json",
+		"testdata/input/yaml/fr-fr.json",
+		"testdata/input/yaml/ar-ar.one.json",
+		"testdata/input/yaml/ar-ar.two.json",
+	}
+	testMergeExecute(t, files)
+}
+
+func testMergeExecute(t *testing.T, files []string) {
+	resetDir(t, "testdata/output")
 
 	mc := &mergeCommand{
 		translationFiles:  files,

--- a/goi18n/testdata/en-us.yaml
+++ b/goi18n/testdata/en-us.yaml
@@ -4,22 +4,27 @@
 - id: person_greeting
   translation: "Hello {{.Person}}"
 
+- id: my_height_in_meters
+  translation:
+    one: "I am {{.Count}} meter tall."
+    other: "I am {{.Count}} meters tall."
+
 - id: your_unread_email_count
-  translations:
+  translation:
     one: "You have {{.Count}} unread email."
     other: "You have {{.Count}} unread emails."
 
 - id: person_unread_email_count
-  translations:
+  translation:
     one: "{{.Person}} has {{.Count}} unread email."
     other: "{{.Person}} has {{.Count}} unread emails."
 
 - id: person_unread_email_count_timeframe
-  translations:
+  translation:
     one: "{{.Person}} has {{.Count}} unread email in the past {{.Timeframe}}."
     other: "{{.Person}} has {{.Count}} unread emails in the past {{.Timeframe}}."
 
 - id: d_days
-  translations:
+  translation:
     one: "{{.Count}} day"
     other: "{{.Count}} days"

--- a/goi18n/testdata/input/yaml/ar-ar.one.json
+++ b/goi18n/testdata/input/yaml/ar-ar.one.json
@@ -1,0 +1,54 @@
+[
+  {
+    "id": "d_days",
+    "translation": {
+      "few": "arabic few translation of d_days",
+      "many": "arabic many translation of d_days",
+      "one": "",
+      "other": "",
+      "two": "",
+      "zero": ""
+    }
+  },
+  {
+    "id": "person_greeting",
+    "translation": "arabic translation of person_greeting"
+  },
+  {
+    "id": "person_unread_email_count",
+    "translation": {
+      "few": "arabic few translation of person_unread_email_count",
+      "many": "arabic many translation of person_unread_email_count",
+      "one": "arabic one translation of person_unread_email_count",
+      "other": "",
+      "two": "",
+      "zero": ""
+    }
+  },
+  {
+    "id": "person_unread_email_count_timeframe",
+    "translation": {
+      "few": "",
+      "many": "",
+      "one": "",
+      "other": "",
+      "two": "",
+      "zero": ""
+    }
+  },
+  {
+    "id": "program_greeting",
+    "translation": ""
+  },
+  {
+    "id": "your_unread_email_count",
+    "translation": {
+      "few": "",
+      "many": "",
+      "one": "",
+      "other": "",
+      "two": "",
+      "zero": ""
+    }
+  }
+]

--- a/goi18n/testdata/input/yaml/ar-ar.two.json
+++ b/goi18n/testdata/input/yaml/ar-ar.two.json
@@ -1,0 +1,54 @@
+[
+  {
+    "id": "d_days",
+    "translation": {
+      "few": "new arabic few translation of d_days",
+      "many": "",
+      "one": "arabic one translation of d_days",
+      "other": "",
+      "two": "",
+      "zero": ""
+    }
+  },
+  {
+    "id": "person_greeting",
+    "translation": "new arabic translation of person_greeting"
+  },
+  {
+    "id": "person_unread_email_count",
+    "translation": {
+      "few": "",
+      "many": "",
+      "one": "",
+      "other": "arabic other translation of person_unread_email_count",
+      "two": "arabic two translation of person_unread_email_count",
+      "zero": "arabic zero translation of person_unread_email_count"
+    }
+  },
+  {
+    "id": "person_unread_email_count_timeframe",
+    "translation": {
+      "few": "",
+      "many": "",
+      "one": "",
+      "other": "",
+      "two": "",
+      "zero": ""
+    }
+  },
+  {
+    "id": "program_greeting",
+    "translation": ""
+  },
+  {
+    "id": "your_unread_email_count",
+    "translation": {
+      "few": "",
+      "many": "",
+      "one": "",
+      "other": "",
+      "two": "",
+      "zero": ""
+    }
+  }
+]

--- a/goi18n/testdata/input/yaml/en-us.one.yaml
+++ b/goi18n/testdata/input/yaml/en-us.one.yaml
@@ -1,0 +1,19 @@
+- id: program_greeting
+  translation: Hello world
+
+- id: your_unread_email_count
+  translation:
+    one: You have {{.Count}} unread email.
+    other: You have {{.Count}} unread emails.
+
+- id: my_height_in_meters
+  translation:
+    one: I am {{.Count}} meter tall.
+    other: I am {{.Count}} meters tall.
+
+- id: person_unread_email_count_timeframe
+  translation:
+    one: "{{.Person}} has {{.Count}} unread email in the past {{.Timeframe}}."
+    
+- id: d_days
+  translation: this should get overwritten

--- a/goi18n/testdata/input/yaml/en-us.two.json
+++ b/goi18n/testdata/input/yaml/en-us.two.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "person_greeting",
+    "translation": "Hello {{.Person}}"
+  },
+  {
+    "id": "person_unread_email_count",
+    "translation": {
+      "one": "{{.Person}} has {{.Count}} unread email.",
+      "other": "{{.Person}} has {{.Count}} unread emails."
+    }
+  },
+  {
+    "id": "person_unread_email_count_timeframe",
+    "translation": {
+      "other": "{{.Person}} has {{.Count}} unread emails in the past {{.Timeframe}}."
+    }
+  },
+  {
+    "id": "d_days",
+    "translation": {
+      "one": "{{.Count}} day",
+      "other": "{{.Count}} days"
+    }
+  }
+]

--- a/i18n/bundle/bundle.go
+++ b/i18n/bundle/bundle.go
@@ -4,10 +4,9 @@ package bundle
 import (
 	"encoding/json"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"reflect"
-
-	//	"launchpad.net/goyaml"
 
 	"path/filepath"
 
@@ -81,10 +80,8 @@ func parseTranslations(filename string, buf []byte) ([]translation.Translation, 
 	switch format := filepath.Ext(filename); format {
 	case ".json":
 		unmarshalFunc = json.Unmarshal
-	/*
-		case ".yaml":
-			unmarshalFunc = goyaml.Unmarshal
-	*/
+	case ".yaml":
+		unmarshalFunc = yaml.Unmarshal
 	default:
 		return nil, fmt.Errorf("unsupported file extension %s", format)
 	}

--- a/i18n/exampleyaml_test.go
+++ b/i18n/exampleyaml_test.go
@@ -1,0 +1,62 @@
+package i18n_test
+
+import (
+	"fmt"
+	"github.com/nicksnyder/go-i18n/i18n"
+)
+
+func ExampleYAML() {
+	i18n.MustLoadTranslationFile("../goi18n/testdata/en-us.yaml")
+
+	T, _ := i18n.Tfunc("en-US")
+
+	bobMap := map[string]interface{}{"Person": "Bob"}
+	bobStruct := struct{ Person string }{Person: "Bob"}
+
+	fmt.Println(T("program_greeting"))
+	fmt.Println(T("person_greeting", bobMap))
+	fmt.Println(T("person_greeting", bobStruct))
+
+	fmt.Println(T("your_unread_email_count", 0))
+	fmt.Println(T("your_unread_email_count", 1))
+	fmt.Println(T("your_unread_email_count", 2))
+	fmt.Println(T("my_height_in_meters", "1.7"))
+
+	fmt.Println(T("person_unread_email_count", 0, bobMap))
+	fmt.Println(T("person_unread_email_count", 1, bobMap))
+	fmt.Println(T("person_unread_email_count", 2, bobMap))
+	fmt.Println(T("person_unread_email_count", 0, bobStruct))
+	fmt.Println(T("person_unread_email_count", 1, bobStruct))
+	fmt.Println(T("person_unread_email_count", 2, bobStruct))
+
+	fmt.Println(T("person_unread_email_count_timeframe", 3, map[string]interface{}{
+		"Person":    "Bob",
+		"Timeframe": T("d_days", 0),
+	}))
+	fmt.Println(T("person_unread_email_count_timeframe", 3, map[string]interface{}{
+		"Person":    "Bob",
+		"Timeframe": T("d_days", 1),
+	}))
+	fmt.Println(T("person_unread_email_count_timeframe", 3, map[string]interface{}{
+		"Person":    "Bob",
+		"Timeframe": T("d_days", 2),
+	}))
+
+	// Output:
+	// Hello world
+	// Hello Bob
+	// Hello Bob
+	// You have 0 unread emails.
+	// You have 1 unread email.
+	// You have 2 unread emails.
+	// I am 1.7 meters tall.
+	// Bob has 0 unread emails.
+	// Bob has 1 unread email.
+	// Bob has 2 unread emails.
+	// Bob has 0 unread emails.
+	// Bob has 1 unread email.
+	// Bob has 2 unread emails.
+	// Bob has 3 unread emails in the past 0 days.
+	// Bob has 3 unread emails in the past 1 day.
+	// Bob has 3 unread emails in the past 2 days.
+}

--- a/i18n/translation/template.go
+++ b/i18n/translation/template.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding"
 	"strings"
-	//"launchpad.net/goyaml"
 	gotemplate "text/template"
 )
 
@@ -60,21 +59,3 @@ func (t *template) parseTemplate(src string) (err error) {
 
 var _ = encoding.TextMarshaler(&template{})
 var _ = encoding.TextUnmarshaler(&template{})
-
-/*
-func (t *template) GetYAML() (tag string, value interface{}) {
-	return "", t.src
-}
-
-func (t *template) SetYAML(tag string, value interface{}) bool {
-	panic(tag)
-	src, ok := value.(string)
-	if !ok {
-		return false
-	}
-	return t.parseTemplate(src) == nil
-}
-
-var _ = goyaml.Getter(&template{})
-var _ = goyaml.Setter(&template{})
-*/


### PR DESCRIPTION
I believe my translators would be more comfortable with YAML due to it's noiseless syntax, so I added support for it.

I also changed one of the test files used by the merge test from JSON to YAML, to make sure we can merge YAML as well.

I also added an example file identical to the original with the sole exception that it parses a YAML file.

