### PR TITLE
Allow use custom language codes

### DIFF
--- a/goi18n/testdata/bar.toml
+++ b/goi18n/testdata/bar.toml
@@ -1,0 +1,7 @@
+# Bavarian language
+
+[program_greeting]
+other = "Servus Wöed"
+
+[your_unread_email_count]
+other = "Du hosd {{.Count}} ungelesne E-Mails"

--- a/i18n/bundle/bundle_test.go
+++ b/i18n/bundle/bundle_test.go
@@ -111,7 +111,7 @@ func TestTfuncAndLanguage(t *testing.T) {
 			spanishLanguage,
 		},
 		{
-			[]string{"zh-CN,fr-XX,es"},
+			[]string{"zh-CN", "fr-XX", "es"},
 			spanishTranslation,
 			spanishLanguage,
 		},

--- a/i18n/language/language_test.go
+++ b/i18n/language/language_test.go
@@ -69,6 +69,42 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestParseFirst(t *testing.T) {
+	tests := []struct {
+		src  string
+		lang *Language
+	}{
+		{"en", &Language{"en", pluralSpecs["en"]}},
+		{"en-US", &Language{"en-us", pluralSpecs["en"]}},
+		{"en_US", &Language{"en-us", pluralSpecs["en"]}},
+		{"en-GB", &Language{"en-gb", pluralSpecs["en"]}},
+		{"zh-CN", &Language{"zh-cn", pluralSpecs["zh"]}},
+		{"zh-TW", &Language{"zh-tw", pluralSpecs["zh"]}},
+		{"pt-BR", &Language{"pt-br", pluralSpecs["pt"]}},
+		{"pt_BR", &Language{"pt-br", pluralSpecs["pt"]}},
+		{"pt-PT", &Language{"pt-pt", pluralSpecs["pt-pt"]}},
+		{"pt_PT", &Language{"pt-pt", pluralSpecs["pt-pt"]}},
+		{"zh-Hans-CN", &Language{"zh-hans-cn", pluralSpecs["zh"]}},
+		{"zh-Hant-TW", &Language{"zh-hant-tw", pluralSpecs["zh"]}},
+		{"en-US-en-US", &Language{"en-us-en-us", pluralSpecs["en"]}},
+		{".en-US..en-US.", &Language{"en-us", pluralSpecs["en"]}},
+		{"en.json", &Language{"en", pluralSpecs["en"]}},
+		{"en-US.json", &Language{"en-us", pluralSpecs["en"]}},
+		{"en-us.json", &Language{"en-us", pluralSpecs["en"]}},
+		{"en-xx.json", &Language{"en-xx", pluralSpecs["en"]}},
+		{"", nil},
+
+		// Custom language tag.
+		// Related to https://github.com/nicksnyder/go-i18n/issues/72.
+		{"bar.toml", &Language{"bar", EmptyPluralSpec}},
+	}
+	for _, test := range tests {
+		lang := ParseFirst(test.src)
+		if !reflect.DeepEqual(lang, test.lang) {
+			t.Errorf("Parse(%q) = %s expected %s", test.src, lang, test.lang)
+		}
+	}
+}
 func TestMatchingTags(t *testing.T) {
 	tests := []struct {
 		lang    *Language

--- a/i18n/language/pluralspec.go
+++ b/i18n/language/pluralspec.go
@@ -12,6 +12,13 @@ type PluralSpec struct {
 
 var pluralSpecs = make(map[string]*PluralSpec)
 
+// EmptyPluralSpec has only Other plural
+// and its PluralFunc always returns Other.
+var EmptyPluralSpec = &PluralSpec{
+	Plurals:    map[Plural]struct{}{Other: struct{}{}},
+	PluralFunc: func(*operands) Plural { return Other },
+}
+
 func normalizePluralSpecID(id string) string {
 	id = strings.Replace(id, "_", "-", -1)
 	id = strings.ToLower(id)
@@ -38,7 +45,6 @@ func (ps *PluralSpec) Plural(number interface{}) (Plural, error) {
 // getPluralSpec returns the PluralSpec that matches the longest prefix of tag.
 // It returns nil if no PluralSpec matches tag.
 func getPluralSpec(tag string) *PluralSpec {
-	tag = NormalizeTag(tag)
 	subtag := tag
 	for {
 		if spec := pluralSpecs[subtag]; spec != nil {

--- a/i18n/language/pluralspec_test.go
+++ b/i18n/language/pluralspec_test.go
@@ -68,7 +68,7 @@ func TestGetPluralSpec(t *testing.T) {
 		{"xx", nil},
 	}
 	for _, test := range tests {
-		spec := getPluralSpec(test.src)
+		spec := getPluralSpec(NormalizeTag(test.src))
 		if spec != test.spec {
 			t.Errorf("getPluralSpec(%q) = %q expected %q", test.src, spec, test.spec)
 		}

--- a/i18n/translations_test.go
+++ b/i18n/translations_test.go
@@ -87,3 +87,36 @@ func TestYAMLFlatParse(t *testing.T) {
 func TestTOMLFlatParse(t *testing.T) {
 	testFile(t, "../goi18n/testdata/en-us.flat.toml")
 }
+
+// TestCustomLanguageTag checks, if go-i18n correctly parses
+// translation file with custom language tags, which aren't registered
+// in Unicode CLDR.
+// As an example we take bavarian language.
+// Related to https://github.com/nicksnyder/go-i18n/issues/72.
+func TestCustomLanguageTag(t *testing.T) {
+	b := bundle.New()
+	if err := b.LoadTranslationFile("../goi18n/testdata/bar.toml"); err != nil {
+		t.Fatal(err)
+	}
+
+	T, err := b.Tfunc("bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		id   string
+		arg  interface{}
+		want string
+	}{
+		{"program_greeting", nil, "Servus Wöed"},
+		{"your_unread_email_count", 7, "Du hosd 7 ungelesne E-Mails"},
+	}
+
+	for _, tc := range testCases {
+		got := T(tc.id, tc.arg)
+		if got != tc.want {
+			t.Error("got: %v; want: %v", got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Fix #72 
Fix https://github.com/spf13/hugo/issues/3564

go-i18n doesn't return an error now, if user provides non-registered language code.

/cc @bep @nicksnyder 