### PR TITLE
Export registerPluralSpec function

### DIFF
--- a/i18n/language/language_test.go
+++ b/i18n/language/language_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestParse(t *testing.T) {
 	tests := []struct {
-		src  string
-		lang []*Language
+		src   string
+		langs []*Language
 	}{
 		{"en", []*Language{{"en", pluralSpecs["en"]}}},
 		{"en-US", []*Language{{"en-us", pluralSpecs["en"]}}},
@@ -62,11 +62,58 @@ func TestParse(t *testing.T) {
 		{"xx", nil},
 	}
 	for _, test := range tests {
-		lang := Parse(test.src)
-		if !reflect.DeepEqual(lang, test.lang) {
-			t.Errorf("Parse(%q) = %s expected %s", test.src, lang, test.lang)
+		langs := Parse(test.src)
+		if len(test.langs) != len(langs) && !reflect.DeepEqual(langs, test.langs) {
+			t.Errorf("Parse(%q) = %s expected %s", test.src, langs, test.langs)
 		}
 	}
+}
+
+func TestAllLanguageTags(t *testing.T) {
+	tests := []struct {
+		src      string
+		expected []string
+	}{
+		{"en", []string{"en"}},
+		{"en-US", []string{"en-us"}},
+		{"en_US", []string{"en-us"}},
+		{"en-GB", []string{"en-gb"}},
+		{"zh-CN", []string{"zh-cn"}},
+		{"zh-TW", []string{"zh-tw"}},
+		{"zh-Hans-CN", []string{"zh-hans-cn"}},
+		{"zh-Hant-TW", []string{"zh-hant-tw"}},
+		{"en-US-en-US", []string{"en-us-en-us"}},
+		{".en-US..en-US.", []string{"en-us"}},
+		{
+			"it, xx-zz, xx-ZZ, zh, en-gb, en, es-ES, de-xx, xx",
+			[]string{"it", "xx-zz", "zh", "en-gb", "en", "es-es", "de-xx", "xx"},
+		},
+		{"en.json", []string{"en"}},
+		{"en-US.json", []string{"en-us"}},
+		{"en-us.json", []string{"en-us"}},
+		{"en-xx.json", []string{"en-xx"}},
+		{"unknown", []string{"unknown"}},
+		{"", nil},
+	}
+	for _, test := range tests {
+		langs := AllLanguageTags(test.src)
+		if !areStringSlicesEqual(langs, test.expected) {
+			t.Errorf("AllLanguages(%q) = %v expected %v", test.src, langs, test.expected)
+		}
+	}
+}
+
+func areStringSlicesEqual(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestMatchingTags(t *testing.T) {

--- a/i18n/language/operands_test.go
+++ b/i18n/language/operands_test.go
@@ -8,37 +8,37 @@ import (
 func TestNewOperands(t *testing.T) {
 	tests := []struct {
 		input interface{}
-		ops   *operands
+		op    *Operand
 		err   bool
 	}{
-		{int64(0), &operands{0.0, 0, 0, 0, 0, 0}, false},
-		{int64(1), &operands{1.0, 1, 0, 0, 0, 0}, false},
-		{"0", &operands{0.0, 0, 0, 0, 0, 0}, false},
-		{"1", &operands{1.0, 1, 0, 0, 0, 0}, false},
-		{"1.0", &operands{1.0, 1, 1, 0, 0, 0}, false},
-		{"1.00", &operands{1.0, 1, 2, 0, 0, 0}, false},
-		{"1.3", &operands{1.3, 1, 1, 1, 3, 3}, false},
-		{"1.30", &operands{1.3, 1, 2, 1, 30, 3}, false},
-		{"1.03", &operands{1.03, 1, 2, 2, 3, 3}, false},
-		{"1.230", &operands{1.23, 1, 3, 2, 230, 23}, false},
-		{"20.0230", &operands{20.023, 20, 4, 3, 230, 23}, false},
+		{int64(0), &Operand{0.0, 0, 0, 0, 0, 0}, false},
+		{int64(1), &Operand{1.0, 1, 0, 0, 0, 0}, false},
+		{"0", &Operand{0.0, 0, 0, 0, 0, 0}, false},
+		{"1", &Operand{1.0, 1, 0, 0, 0, 0}, false},
+		{"1.0", &Operand{1.0, 1, 1, 0, 0, 0}, false},
+		{"1.00", &Operand{1.0, 1, 2, 0, 0, 0}, false},
+		{"1.3", &Operand{1.3, 1, 1, 1, 3, 3}, false},
+		{"1.30", &Operand{1.3, 1, 2, 1, 30, 3}, false},
+		{"1.03", &Operand{1.03, 1, 2, 2, 3, 3}, false},
+		{"1.230", &Operand{1.23, 1, 3, 2, 230, 23}, false},
+		{"20.0230", &Operand{20.023, 20, 4, 3, 230, 23}, false},
 		{20.0230, nil, true},
 	}
 	for _, test := range tests {
-		ops, err := newOperands(test.input)
+		op, err := newOperand(test.input)
 		if err != nil && !test.err {
 			t.Errorf("newOperands(%#v) unexpected error: %s", test.input, err)
 		} else if err == nil && test.err {
-			t.Errorf("newOperands(%#v) returned %#v; expected error", test.input, ops)
-		} else if !reflect.DeepEqual(ops, test.ops) {
-			t.Errorf("newOperands(%#v) returned %#v; expected %#v", test.input, ops, test.ops)
+			t.Errorf("newOperands(%#v) returned %#v; expected error", test.input, op)
+		} else if !reflect.DeepEqual(op, test.op) {
+			t.Errorf("newOperands(%#v) returned %#v; expected %#v", test.input, op, test.op)
 		}
 	}
 }
 
 func BenchmarkNewOperand(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		if _, err := newOperands("1234.56780000"); err != nil {
+		if _, err := newOperand("1234.56780000"); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/i18n/language/pluralspec.go
+++ b/i18n/language/pluralspec.go
@@ -18,10 +18,11 @@ func normalizePluralSpecID(id string) string {
 	return id
 }
 
-func registerPluralSpec(ids []string, ps *PluralSpec) {
+// RegisterPluralSpec registers pluralSpec for ids.
+func RegisterPluralSpec(ids []string, pluralSpec *PluralSpec) {
 	for _, id := range ids {
 		id = normalizePluralSpecID(id)
-		pluralSpecs[id] = ps
+		pluralSpecs[id] = pluralSpec
 	}
 }
 

--- a/i18n/language/pluralspec.go
+++ b/i18n/language/pluralspec.go
@@ -7,7 +7,7 @@ import "strings"
 // http://unicode.org/reports/tr35/tr35-numbers.html#Operands
 type PluralSpec struct {
 	Plurals    map[Plural]struct{}
-	PluralFunc func(*operands) Plural
+	PluralFunc func(*Operand) Plural
 }
 
 var pluralSpecs = make(map[string]*PluralSpec)
@@ -29,11 +29,11 @@ func RegisterPluralSpec(ids []string, pluralSpec *PluralSpec) {
 // Plural returns the plural category for number as defined by
 // the language's CLDR plural rules.
 func (ps *PluralSpec) Plural(number interface{}) (Plural, error) {
-	ops, err := newOperands(number)
+	op, err := newOperand(number)
 	if err != nil {
 		return Invalid, err
 	}
-	return ps.PluralFunc(ops), nil
+	return ps.PluralFunc(op), nil
 }
 
 // getPluralSpec returns the PluralSpec that matches the longest prefix of tag.

--- a/i18n/language/pluralspec.go
+++ b/i18n/language/pluralspec.go
@@ -12,6 +12,13 @@ type PluralSpec struct {
 
 var pluralSpecs = make(map[string]*PluralSpec)
 
+// EmptyPluralSpec has only Other plural
+// and its PluralFunc always returns Other.
+var EmptyPluralSpec = &PluralSpec{
+	Plurals:    map[Plural]struct{}{Other: struct{}{}},
+	PluralFunc: func(*Operand) Plural { return Other },
+}
+
 func normalizePluralSpecID(id string) string {
 	id = strings.Replace(id, "_", "-", -1)
 	id = strings.ToLower(id)

--- a/i18n/language/pluralspec_gen.go
+++ b/i18n/language/pluralspec_gen.go
@@ -6,16 +6,16 @@ func init() {
 
 	RegisterPluralSpec([]string{"bm", "bo", "dz", "id", "ig", "ii", "in", "ja", "jbo", "jv", "jw", "kde", "kea", "km", "ko", "lkt", "lo", "ms", "my", "nqo", "root", "sah", "ses", "sg", "th", "to", "vi", "wo", "yo", "zh"}, &PluralSpec{
 		Plurals: newPluralSet(Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			return Other
 		},
 	})
 	RegisterPluralSpec([]string{"am", "as", "bn", "fa", "gu", "hi", "kn", "mr", "zu"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// i = 0 or n = 1
-			if intEqualsAny(ops.I, 0) ||
-				ops.NequalsAny(1) {
+			if intEqualsAny(op.I, 0) ||
+				op.NequalsAny(1) {
 				return One
 			}
 			return Other
@@ -23,9 +23,9 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"ff", "fr", "hy", "kab"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// i = 0,1
-			if intEqualsAny(ops.I, 0, 1) {
+			if intEqualsAny(op.I, 0, 1) {
 				return One
 			}
 			return Other
@@ -33,9 +33,9 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"ast", "ca", "de", "en", "et", "fi", "fy", "gl", "it", "ji", "nl", "sv", "sw", "ur", "yi"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// i = 1 and v = 0
-			if intEqualsAny(ops.I, 1) && intEqualsAny(ops.V, 0) {
+			if intEqualsAny(op.I, 1) && intEqualsAny(op.V, 0) {
 				return One
 			}
 			return Other
@@ -43,10 +43,10 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"si"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 0,1 or i = 0 and f = 1
-			if ops.NequalsAny(0, 1) ||
-				intEqualsAny(ops.I, 0) && intEqualsAny(ops.F, 1) {
+			if op.NequalsAny(0, 1) ||
+				intEqualsAny(op.I, 0) && intEqualsAny(op.F, 1) {
 				return One
 			}
 			return Other
@@ -54,9 +54,9 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"ak", "bh", "guw", "ln", "mg", "nso", "pa", "ti", "wa"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 0..1
-			if ops.NinRange(0, 1) {
+			if op.NinRange(0, 1) {
 				return One
 			}
 			return Other
@@ -64,10 +64,10 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"tzm"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 0..1 or n = 11..99
-			if ops.NinRange(0, 1) ||
-				ops.NinRange(11, 99) {
+			if op.NinRange(0, 1) ||
+				op.NinRange(11, 99) {
 				return One
 			}
 			return Other
@@ -75,9 +75,9 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"pt"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 0..2 and n != 2
-			if ops.NinRange(0, 2) && !ops.NequalsAny(2) {
+			if op.NinRange(0, 2) && !op.NequalsAny(2) {
 				return One
 			}
 			return Other
@@ -85,9 +85,9 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"af", "asa", "az", "bem", "bez", "bg", "brx", "ce", "cgg", "chr", "ckb", "dv", "ee", "el", "eo", "es", "eu", "fo", "fur", "gsw", "ha", "haw", "hu", "jgo", "jmc", "ka", "kaj", "kcg", "kk", "kkj", "kl", "ks", "ksb", "ku", "ky", "lb", "lg", "mas", "mgo", "ml", "mn", "nah", "nb", "nd", "ne", "nn", "nnh", "no", "nr", "ny", "nyn", "om", "or", "os", "pap", "ps", "rm", "rof", "rwk", "saq", "sdh", "seh", "sn", "so", "sq", "ss", "ssy", "st", "syr", "ta", "te", "teo", "tig", "tk", "tn", "tr", "ts", "ug", "uz", "ve", "vo", "vun", "wae", "xh", "xog"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 1
-			if ops.NequalsAny(1) {
+			if op.NequalsAny(1) {
 				return One
 			}
 			return Other
@@ -95,9 +95,9 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"pt_PT"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 1 and v = 0
-			if ops.NequalsAny(1) && intEqualsAny(ops.V, 0) {
+			if op.NequalsAny(1) && intEqualsAny(op.V, 0) {
 				return One
 			}
 			return Other
@@ -105,10 +105,10 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"da"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 1 or t != 0 and i = 0,1
-			if ops.NequalsAny(1) ||
-				!intEqualsAny(ops.T, 0) && intEqualsAny(ops.I, 0, 1) {
+			if op.NequalsAny(1) ||
+				!intEqualsAny(op.T, 0) && intEqualsAny(op.I, 0, 1) {
 				return One
 			}
 			return Other
@@ -116,10 +116,10 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"is"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// t = 0 and i % 10 = 1 and i % 100 != 11 or t != 0
-			if intEqualsAny(ops.T, 0) && intEqualsAny(ops.I%10, 1) && !intEqualsAny(ops.I%100, 11) ||
-				!intEqualsAny(ops.T, 0) {
+			if intEqualsAny(op.T, 0) && intEqualsAny(op.I%10, 1) && !intEqualsAny(op.I%100, 11) ||
+				!intEqualsAny(op.T, 0) {
 				return One
 			}
 			return Other
@@ -127,10 +127,10 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"mk"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// v = 0 and i % 10 = 1 or f % 10 = 1
-			if intEqualsAny(ops.V, 0) && intEqualsAny(ops.I%10, 1) ||
-				intEqualsAny(ops.F%10, 1) {
+			if intEqualsAny(op.V, 0) && intEqualsAny(op.I%10, 1) ||
+				intEqualsAny(op.F%10, 1) {
 				return One
 			}
 			return Other
@@ -138,11 +138,11 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"fil", "tl"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// v = 0 and i = 1,2,3 or v = 0 and i % 10 != 4,6,9 or v != 0 and f % 10 != 4,6,9
-			if intEqualsAny(ops.V, 0) && intEqualsAny(ops.I, 1, 2, 3) ||
-				intEqualsAny(ops.V, 0) && !intEqualsAny(ops.I%10, 4, 6, 9) ||
-				!intEqualsAny(ops.V, 0) && !intEqualsAny(ops.F%10, 4, 6, 9) {
+			if intEqualsAny(op.V, 0) && intEqualsAny(op.I, 1, 2, 3) ||
+				intEqualsAny(op.V, 0) && !intEqualsAny(op.I%10, 4, 6, 9) ||
+				!intEqualsAny(op.V, 0) && !intEqualsAny(op.F%10, 4, 6, 9) {
 				return One
 			}
 			return Other
@@ -150,17 +150,17 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"lv", "prg"}, &PluralSpec{
 		Plurals: newPluralSet(Zero, One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n % 10 = 0 or n % 100 = 11..19 or v = 2 and f % 100 = 11..19
-			if ops.NmodEqualsAny(10, 0) ||
-				ops.NmodInRange(100, 11, 19) ||
-				intEqualsAny(ops.V, 2) && intInRange(ops.F%100, 11, 19) {
+			if op.NmodEqualsAny(10, 0) ||
+				op.NmodInRange(100, 11, 19) ||
+				intEqualsAny(op.V, 2) && intInRange(op.F%100, 11, 19) {
 				return Zero
 			}
 			// n % 10 = 1 and n % 100 != 11 or v = 2 and f % 10 = 1 and f % 100 != 11 or v != 2 and f % 10 = 1
-			if ops.NmodEqualsAny(10, 1) && !ops.NmodEqualsAny(100, 11) ||
-				intEqualsAny(ops.V, 2) && intEqualsAny(ops.F%10, 1) && !intEqualsAny(ops.F%100, 11) ||
-				!intEqualsAny(ops.V, 2) && intEqualsAny(ops.F%10, 1) {
+			if op.NmodEqualsAny(10, 1) && !op.NmodEqualsAny(100, 11) ||
+				intEqualsAny(op.V, 2) && intEqualsAny(op.F%10, 1) && !intEqualsAny(op.F%100, 11) ||
+				!intEqualsAny(op.V, 2) && intEqualsAny(op.F%10, 1) {
 				return One
 			}
 			return Other
@@ -168,13 +168,13 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"lag"}, &PluralSpec{
 		Plurals: newPluralSet(Zero, One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 0
-			if ops.NequalsAny(0) {
+			if op.NequalsAny(0) {
 				return Zero
 			}
 			// i = 0,1 and n != 0
-			if intEqualsAny(ops.I, 0, 1) && !ops.NequalsAny(0) {
+			if intEqualsAny(op.I, 0, 1) && !op.NequalsAny(0) {
 				return One
 			}
 			return Other
@@ -182,13 +182,13 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"ksh"}, &PluralSpec{
 		Plurals: newPluralSet(Zero, One, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 0
-			if ops.NequalsAny(0) {
+			if op.NequalsAny(0) {
 				return Zero
 			}
 			// n = 1
-			if ops.NequalsAny(1) {
+			if op.NequalsAny(1) {
 				return One
 			}
 			return Other
@@ -196,13 +196,13 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"iu", "kw", "naq", "se", "sma", "smi", "smj", "smn", "sms"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 1
-			if ops.NequalsAny(1) {
+			if op.NequalsAny(1) {
 				return One
 			}
 			// n = 2
-			if ops.NequalsAny(2) {
+			if op.NequalsAny(2) {
 				return Two
 			}
 			return Other
@@ -210,14 +210,14 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"shi"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// i = 0 or n = 1
-			if intEqualsAny(ops.I, 0) ||
-				ops.NequalsAny(1) {
+			if intEqualsAny(op.I, 0) ||
+				op.NequalsAny(1) {
 				return One
 			}
 			// n = 2..10
-			if ops.NinRange(2, 10) {
+			if op.NinRange(2, 10) {
 				return Few
 			}
 			return Other
@@ -225,15 +225,15 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"mo", "ro"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// i = 1 and v = 0
-			if intEqualsAny(ops.I, 1) && intEqualsAny(ops.V, 0) {
+			if intEqualsAny(op.I, 1) && intEqualsAny(op.V, 0) {
 				return One
 			}
 			// v != 0 or n = 0 or n != 1 and n % 100 = 1..19
-			if !intEqualsAny(ops.V, 0) ||
-				ops.NequalsAny(0) ||
-				!ops.NequalsAny(1) && ops.NmodInRange(100, 1, 19) {
+			if !intEqualsAny(op.V, 0) ||
+				op.NequalsAny(0) ||
+				!op.NequalsAny(1) && op.NmodInRange(100, 1, 19) {
 				return Few
 			}
 			return Other
@@ -241,15 +241,15 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"bs", "hr", "sh", "sr"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// v = 0 and i % 10 = 1 and i % 100 != 11 or f % 10 = 1 and f % 100 != 11
-			if intEqualsAny(ops.V, 0) && intEqualsAny(ops.I%10, 1) && !intEqualsAny(ops.I%100, 11) ||
-				intEqualsAny(ops.F%10, 1) && !intEqualsAny(ops.F%100, 11) {
+			if intEqualsAny(op.V, 0) && intEqualsAny(op.I%10, 1) && !intEqualsAny(op.I%100, 11) ||
+				intEqualsAny(op.F%10, 1) && !intEqualsAny(op.F%100, 11) {
 				return One
 			}
 			// v = 0 and i % 10 = 2..4 and i % 100 != 12..14 or f % 10 = 2..4 and f % 100 != 12..14
-			if intEqualsAny(ops.V, 0) && intInRange(ops.I%10, 2, 4) && !intInRange(ops.I%100, 12, 14) ||
-				intInRange(ops.F%10, 2, 4) && !intInRange(ops.F%100, 12, 14) {
+			if intEqualsAny(op.V, 0) && intInRange(op.I%10, 2, 4) && !intInRange(op.I%100, 12, 14) ||
+				intInRange(op.F%10, 2, 4) && !intInRange(op.F%100, 12, 14) {
 				return Few
 			}
 			return Other
@@ -257,17 +257,17 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"gd"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Few, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 1,11
-			if ops.NequalsAny(1, 11) {
+			if op.NequalsAny(1, 11) {
 				return One
 			}
 			// n = 2,12
-			if ops.NequalsAny(2, 12) {
+			if op.NequalsAny(2, 12) {
 				return Two
 			}
 			// n = 3..10,13..19
-			if ops.NinRange(3, 10) || ops.NinRange(13, 19) {
+			if op.NinRange(3, 10) || op.NinRange(13, 19) {
 				return Few
 			}
 			return Other
@@ -275,18 +275,18 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"sl"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Few, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// v = 0 and i % 100 = 1
-			if intEqualsAny(ops.V, 0) && intEqualsAny(ops.I%100, 1) {
+			if intEqualsAny(op.V, 0) && intEqualsAny(op.I%100, 1) {
 				return One
 			}
 			// v = 0 and i % 100 = 2
-			if intEqualsAny(ops.V, 0) && intEqualsAny(ops.I%100, 2) {
+			if intEqualsAny(op.V, 0) && intEqualsAny(op.I%100, 2) {
 				return Two
 			}
 			// v = 0 and i % 100 = 3..4 or v != 0
-			if intEqualsAny(ops.V, 0) && intInRange(ops.I%100, 3, 4) ||
-				!intEqualsAny(ops.V, 0) {
+			if intEqualsAny(op.V, 0) && intInRange(op.I%100, 3, 4) ||
+				!intEqualsAny(op.V, 0) {
 				return Few
 			}
 			return Other
@@ -294,20 +294,20 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"dsb", "hsb"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Few, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// v = 0 and i % 100 = 1 or f % 100 = 1
-			if intEqualsAny(ops.V, 0) && intEqualsAny(ops.I%100, 1) ||
-				intEqualsAny(ops.F%100, 1) {
+			if intEqualsAny(op.V, 0) && intEqualsAny(op.I%100, 1) ||
+				intEqualsAny(op.F%100, 1) {
 				return One
 			}
 			// v = 0 and i % 100 = 2 or f % 100 = 2
-			if intEqualsAny(ops.V, 0) && intEqualsAny(ops.I%100, 2) ||
-				intEqualsAny(ops.F%100, 2) {
+			if intEqualsAny(op.V, 0) && intEqualsAny(op.I%100, 2) ||
+				intEqualsAny(op.F%100, 2) {
 				return Two
 			}
 			// v = 0 and i % 100 = 3..4 or f % 100 = 3..4
-			if intEqualsAny(ops.V, 0) && intInRange(ops.I%100, 3, 4) ||
-				intInRange(ops.F%100, 3, 4) {
+			if intEqualsAny(op.V, 0) && intInRange(op.I%100, 3, 4) ||
+				intInRange(op.F%100, 3, 4) {
 				return Few
 			}
 			return Other
@@ -315,17 +315,17 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"he", "iw"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Many, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// i = 1 and v = 0
-			if intEqualsAny(ops.I, 1) && intEqualsAny(ops.V, 0) {
+			if intEqualsAny(op.I, 1) && intEqualsAny(op.V, 0) {
 				return One
 			}
 			// i = 2 and v = 0
-			if intEqualsAny(ops.I, 2) && intEqualsAny(ops.V, 0) {
+			if intEqualsAny(op.I, 2) && intEqualsAny(op.V, 0) {
 				return Two
 			}
 			// v = 0 and n != 0..10 and n % 10 = 0
-			if intEqualsAny(ops.V, 0) && !ops.NinRange(0, 10) && ops.NmodEqualsAny(10, 0) {
+			if intEqualsAny(op.V, 0) && !op.NinRange(0, 10) && op.NmodEqualsAny(10, 0) {
 				return Many
 			}
 			return Other
@@ -333,17 +333,17 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"cs", "sk"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Many, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// i = 1 and v = 0
-			if intEqualsAny(ops.I, 1) && intEqualsAny(ops.V, 0) {
+			if intEqualsAny(op.I, 1) && intEqualsAny(op.V, 0) {
 				return One
 			}
 			// i = 2..4 and v = 0
-			if intInRange(ops.I, 2, 4) && intEqualsAny(ops.V, 0) {
+			if intInRange(op.I, 2, 4) && intEqualsAny(op.V, 0) {
 				return Few
 			}
 			// v != 0
-			if !intEqualsAny(ops.V, 0) {
+			if !intEqualsAny(op.V, 0) {
 				return Many
 			}
 			return Other
@@ -351,19 +351,19 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"pl"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Many, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// i = 1 and v = 0
-			if intEqualsAny(ops.I, 1) && intEqualsAny(ops.V, 0) {
+			if intEqualsAny(op.I, 1) && intEqualsAny(op.V, 0) {
 				return One
 			}
 			// v = 0 and i % 10 = 2..4 and i % 100 != 12..14
-			if intEqualsAny(ops.V, 0) && intInRange(ops.I%10, 2, 4) && !intInRange(ops.I%100, 12, 14) {
+			if intEqualsAny(op.V, 0) && intInRange(op.I%10, 2, 4) && !intInRange(op.I%100, 12, 14) {
 				return Few
 			}
 			// v = 0 and i != 1 and i % 10 = 0..1 or v = 0 and i % 10 = 5..9 or v = 0 and i % 100 = 12..14
-			if intEqualsAny(ops.V, 0) && !intEqualsAny(ops.I, 1) && intInRange(ops.I%10, 0, 1) ||
-				intEqualsAny(ops.V, 0) && intInRange(ops.I%10, 5, 9) ||
-				intEqualsAny(ops.V, 0) && intInRange(ops.I%100, 12, 14) {
+			if intEqualsAny(op.V, 0) && !intEqualsAny(op.I, 1) && intInRange(op.I%10, 0, 1) ||
+				intEqualsAny(op.V, 0) && intInRange(op.I%10, 5, 9) ||
+				intEqualsAny(op.V, 0) && intInRange(op.I%100, 12, 14) {
 				return Many
 			}
 			return Other
@@ -371,19 +371,19 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"be"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Many, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n % 10 = 1 and n % 100 != 11
-			if ops.NmodEqualsAny(10, 1) && !ops.NmodEqualsAny(100, 11) {
+			if op.NmodEqualsAny(10, 1) && !op.NmodEqualsAny(100, 11) {
 				return One
 			}
 			// n % 10 = 2..4 and n % 100 != 12..14
-			if ops.NmodInRange(10, 2, 4) && !ops.NmodInRange(100, 12, 14) {
+			if op.NmodInRange(10, 2, 4) && !op.NmodInRange(100, 12, 14) {
 				return Few
 			}
 			// n % 10 = 0 or n % 10 = 5..9 or n % 100 = 11..14
-			if ops.NmodEqualsAny(10, 0) ||
-				ops.NmodInRange(10, 5, 9) ||
-				ops.NmodInRange(100, 11, 14) {
+			if op.NmodEqualsAny(10, 0) ||
+				op.NmodInRange(10, 5, 9) ||
+				op.NmodInRange(100, 11, 14) {
 				return Many
 			}
 			return Other
@@ -391,17 +391,17 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"lt"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Many, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n % 10 = 1 and n % 100 != 11..19
-			if ops.NmodEqualsAny(10, 1) && !ops.NmodInRange(100, 11, 19) {
+			if op.NmodEqualsAny(10, 1) && !op.NmodInRange(100, 11, 19) {
 				return One
 			}
 			// n % 10 = 2..9 and n % 100 != 11..19
-			if ops.NmodInRange(10, 2, 9) && !ops.NmodInRange(100, 11, 19) {
+			if op.NmodInRange(10, 2, 9) && !op.NmodInRange(100, 11, 19) {
 				return Few
 			}
 			// f != 0
-			if !intEqualsAny(ops.F, 0) {
+			if !intEqualsAny(op.F, 0) {
 				return Many
 			}
 			return Other
@@ -409,18 +409,18 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"mt"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Many, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 1
-			if ops.NequalsAny(1) {
+			if op.NequalsAny(1) {
 				return One
 			}
 			// n = 0 or n % 100 = 2..10
-			if ops.NequalsAny(0) ||
-				ops.NmodInRange(100, 2, 10) {
+			if op.NequalsAny(0) ||
+				op.NmodInRange(100, 2, 10) {
 				return Few
 			}
 			// n % 100 = 11..19
-			if ops.NmodInRange(100, 11, 19) {
+			if op.NmodInRange(100, 11, 19) {
 				return Many
 			}
 			return Other
@@ -428,19 +428,19 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"ru", "uk"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Many, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// v = 0 and i % 10 = 1 and i % 100 != 11
-			if intEqualsAny(ops.V, 0) && intEqualsAny(ops.I%10, 1) && !intEqualsAny(ops.I%100, 11) {
+			if intEqualsAny(op.V, 0) && intEqualsAny(op.I%10, 1) && !intEqualsAny(op.I%100, 11) {
 				return One
 			}
 			// v = 0 and i % 10 = 2..4 and i % 100 != 12..14
-			if intEqualsAny(ops.V, 0) && intInRange(ops.I%10, 2, 4) && !intInRange(ops.I%100, 12, 14) {
+			if intEqualsAny(op.V, 0) && intInRange(op.I%10, 2, 4) && !intInRange(op.I%100, 12, 14) {
 				return Few
 			}
 			// v = 0 and i % 10 = 0 or v = 0 and i % 10 = 5..9 or v = 0 and i % 100 = 11..14
-			if intEqualsAny(ops.V, 0) && intEqualsAny(ops.I%10, 0) ||
-				intEqualsAny(ops.V, 0) && intInRange(ops.I%10, 5, 9) ||
-				intEqualsAny(ops.V, 0) && intInRange(ops.I%100, 11, 14) {
+			if intEqualsAny(op.V, 0) && intEqualsAny(op.I%10, 0) ||
+				intEqualsAny(op.V, 0) && intInRange(op.I%10, 5, 9) ||
+				intEqualsAny(op.V, 0) && intInRange(op.I%100, 11, 14) {
 				return Many
 			}
 			return Other
@@ -448,21 +448,21 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"br"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Few, Many, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n % 10 = 1 and n % 100 != 11,71,91
-			if ops.NmodEqualsAny(10, 1) && !ops.NmodEqualsAny(100, 11, 71, 91) {
+			if op.NmodEqualsAny(10, 1) && !op.NmodEqualsAny(100, 11, 71, 91) {
 				return One
 			}
 			// n % 10 = 2 and n % 100 != 12,72,92
-			if ops.NmodEqualsAny(10, 2) && !ops.NmodEqualsAny(100, 12, 72, 92) {
+			if op.NmodEqualsAny(10, 2) && !op.NmodEqualsAny(100, 12, 72, 92) {
 				return Two
 			}
 			// n % 10 = 3..4,9 and n % 100 != 10..19,70..79,90..99
-			if (ops.NmodInRange(10, 3, 4) || ops.NmodEqualsAny(10, 9)) && !(ops.NmodInRange(100, 10, 19) || ops.NmodInRange(100, 70, 79) || ops.NmodInRange(100, 90, 99)) {
+			if (op.NmodInRange(10, 3, 4) || op.NmodEqualsAny(10, 9)) && !(op.NmodInRange(100, 10, 19) || op.NmodInRange(100, 70, 79) || op.NmodInRange(100, 90, 99)) {
 				return Few
 			}
 			// n != 0 and n % 1000000 = 0
-			if !ops.NequalsAny(0) && ops.NmodEqualsAny(1000000, 0) {
+			if !op.NequalsAny(0) && op.NmodEqualsAny(1000000, 0) {
 				return Many
 			}
 			return Other
@@ -470,21 +470,21 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"ga"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Few, Many, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 1
-			if ops.NequalsAny(1) {
+			if op.NequalsAny(1) {
 				return One
 			}
 			// n = 2
-			if ops.NequalsAny(2) {
+			if op.NequalsAny(2) {
 				return Two
 			}
 			// n = 3..6
-			if ops.NinRange(3, 6) {
+			if op.NinRange(3, 6) {
 				return Few
 			}
 			// n = 7..10
-			if ops.NinRange(7, 10) {
+			if op.NinRange(7, 10) {
 				return Many
 			}
 			return Other
@@ -492,21 +492,21 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"gv"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Few, Many, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// v = 0 and i % 10 = 1
-			if intEqualsAny(ops.V, 0) && intEqualsAny(ops.I%10, 1) {
+			if intEqualsAny(op.V, 0) && intEqualsAny(op.I%10, 1) {
 				return One
 			}
 			// v = 0 and i % 10 = 2
-			if intEqualsAny(ops.V, 0) && intEqualsAny(ops.I%10, 2) {
+			if intEqualsAny(op.V, 0) && intEqualsAny(op.I%10, 2) {
 				return Two
 			}
 			// v = 0 and i % 100 = 0,20,40,60,80
-			if intEqualsAny(ops.V, 0) && intEqualsAny(ops.I%100, 0, 20, 40, 60, 80) {
+			if intEqualsAny(op.V, 0) && intEqualsAny(op.I%100, 0, 20, 40, 60, 80) {
 				return Few
 			}
 			// v != 0
-			if !intEqualsAny(ops.V, 0) {
+			if !intEqualsAny(op.V, 0) {
 				return Many
 			}
 			return Other
@@ -514,25 +514,25 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"ar"}, &PluralSpec{
 		Plurals: newPluralSet(Zero, One, Two, Few, Many, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 0
-			if ops.NequalsAny(0) {
+			if op.NequalsAny(0) {
 				return Zero
 			}
 			// n = 1
-			if ops.NequalsAny(1) {
+			if op.NequalsAny(1) {
 				return One
 			}
 			// n = 2
-			if ops.NequalsAny(2) {
+			if op.NequalsAny(2) {
 				return Two
 			}
 			// n % 100 = 3..10
-			if ops.NmodInRange(100, 3, 10) {
+			if op.NmodInRange(100, 3, 10) {
 				return Few
 			}
 			// n % 100 = 11..99
-			if ops.NmodInRange(100, 11, 99) {
+			if op.NmodInRange(100, 11, 99) {
 				return Many
 			}
 			return Other
@@ -540,25 +540,25 @@ func init() {
 	})
 	RegisterPluralSpec([]string{"cy"}, &PluralSpec{
 		Plurals: newPluralSet(Zero, One, Two, Few, Many, Other),
-		PluralFunc: func(ops *operands) Plural {
+		PluralFunc: func(op *Operand) Plural {
 			// n = 0
-			if ops.NequalsAny(0) {
+			if op.NequalsAny(0) {
 				return Zero
 			}
 			// n = 1
-			if ops.NequalsAny(1) {
+			if op.NequalsAny(1) {
 				return One
 			}
 			// n = 2
-			if ops.NequalsAny(2) {
+			if op.NequalsAny(2) {
 				return Two
 			}
 			// n = 3
-			if ops.NequalsAny(3) {
+			if op.NequalsAny(3) {
 				return Few
 			}
 			// n = 6
-			if ops.NequalsAny(6) {
+			if op.NequalsAny(6) {
 				return Many
 			}
 			return Other

--- a/i18n/language/pluralspec_gen.go
+++ b/i18n/language/pluralspec_gen.go
@@ -4,13 +4,13 @@ package language
 
 func init() {
 
-	registerPluralSpec([]string{"bm", "bo", "dz", "id", "ig", "ii", "in", "ja", "jbo", "jv", "jw", "kde", "kea", "km", "ko", "lkt", "lo", "ms", "my", "nqo", "root", "sah", "ses", "sg", "th", "to", "vi", "wo", "yo", "zh"}, &PluralSpec{
+	RegisterPluralSpec([]string{"bm", "bo", "dz", "id", "ig", "ii", "in", "ja", "jbo", "jv", "jw", "kde", "kea", "km", "ko", "lkt", "lo", "ms", "my", "nqo", "root", "sah", "ses", "sg", "th", "to", "vi", "wo", "yo", "zh"}, &PluralSpec{
 		Plurals: newPluralSet(Other),
 		PluralFunc: func(ops *operands) Plural {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"am", "as", "bn", "fa", "gu", "hi", "kn", "mr", "zu"}, &PluralSpec{
+	RegisterPluralSpec([]string{"am", "as", "bn", "fa", "gu", "hi", "kn", "mr", "zu"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// i = 0 or n = 1
@@ -21,7 +21,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"ff", "fr", "hy", "kab"}, &PluralSpec{
+	RegisterPluralSpec([]string{"ff", "fr", "hy", "kab"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// i = 0,1
@@ -31,7 +31,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"ast", "ca", "de", "en", "et", "fi", "fy", "gl", "it", "ji", "nl", "sv", "sw", "ur", "yi"}, &PluralSpec{
+	RegisterPluralSpec([]string{"ast", "ca", "de", "en", "et", "fi", "fy", "gl", "it", "ji", "nl", "sv", "sw", "ur", "yi"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// i = 1 and v = 0
@@ -41,7 +41,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"si"}, &PluralSpec{
+	RegisterPluralSpec([]string{"si"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 0,1 or i = 0 and f = 1
@@ -52,7 +52,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"ak", "bh", "guw", "ln", "mg", "nso", "pa", "ti", "wa"}, &PluralSpec{
+	RegisterPluralSpec([]string{"ak", "bh", "guw", "ln", "mg", "nso", "pa", "ti", "wa"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 0..1
@@ -62,7 +62,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"tzm"}, &PluralSpec{
+	RegisterPluralSpec([]string{"tzm"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 0..1 or n = 11..99
@@ -73,7 +73,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"pt"}, &PluralSpec{
+	RegisterPluralSpec([]string{"pt"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 0..2 and n != 2
@@ -83,7 +83,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"af", "asa", "az", "bem", "bez", "bg", "brx", "ce", "cgg", "chr", "ckb", "dv", "ee", "el", "eo", "es", "eu", "fo", "fur", "gsw", "ha", "haw", "hu", "jgo", "jmc", "ka", "kaj", "kcg", "kk", "kkj", "kl", "ks", "ksb", "ku", "ky", "lb", "lg", "mas", "mgo", "ml", "mn", "nah", "nb", "nd", "ne", "nn", "nnh", "no", "nr", "ny", "nyn", "om", "or", "os", "pap", "ps", "rm", "rof", "rwk", "saq", "sdh", "seh", "sn", "so", "sq", "ss", "ssy", "st", "syr", "ta", "te", "teo", "tig", "tk", "tn", "tr", "ts", "ug", "uz", "ve", "vo", "vun", "wae", "xh", "xog"}, &PluralSpec{
+	RegisterPluralSpec([]string{"af", "asa", "az", "bem", "bez", "bg", "brx", "ce", "cgg", "chr", "ckb", "dv", "ee", "el", "eo", "es", "eu", "fo", "fur", "gsw", "ha", "haw", "hu", "jgo", "jmc", "ka", "kaj", "kcg", "kk", "kkj", "kl", "ks", "ksb", "ku", "ky", "lb", "lg", "mas", "mgo", "ml", "mn", "nah", "nb", "nd", "ne", "nn", "nnh", "no", "nr", "ny", "nyn", "om", "or", "os", "pap", "ps", "rm", "rof", "rwk", "saq", "sdh", "seh", "sn", "so", "sq", "ss", "ssy", "st", "syr", "ta", "te", "teo", "tig", "tk", "tn", "tr", "ts", "ug", "uz", "ve", "vo", "vun", "wae", "xh", "xog"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 1
@@ -93,7 +93,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"pt_PT"}, &PluralSpec{
+	RegisterPluralSpec([]string{"pt_PT"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 1 and v = 0
@@ -103,7 +103,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"da"}, &PluralSpec{
+	RegisterPluralSpec([]string{"da"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 1 or t != 0 and i = 0,1
@@ -114,7 +114,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"is"}, &PluralSpec{
+	RegisterPluralSpec([]string{"is"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// t = 0 and i % 10 = 1 and i % 100 != 11 or t != 0
@@ -125,7 +125,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"mk"}, &PluralSpec{
+	RegisterPluralSpec([]string{"mk"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// v = 0 and i % 10 = 1 or f % 10 = 1
@@ -136,7 +136,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"fil", "tl"}, &PluralSpec{
+	RegisterPluralSpec([]string{"fil", "tl"}, &PluralSpec{
 		Plurals: newPluralSet(One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// v = 0 and i = 1,2,3 or v = 0 and i % 10 != 4,6,9 or v != 0 and f % 10 != 4,6,9
@@ -148,7 +148,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"lv", "prg"}, &PluralSpec{
+	RegisterPluralSpec([]string{"lv", "prg"}, &PluralSpec{
 		Plurals: newPluralSet(Zero, One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n % 10 = 0 or n % 100 = 11..19 or v = 2 and f % 100 = 11..19
@@ -166,7 +166,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"lag"}, &PluralSpec{
+	RegisterPluralSpec([]string{"lag"}, &PluralSpec{
 		Plurals: newPluralSet(Zero, One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 0
@@ -180,7 +180,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"ksh"}, &PluralSpec{
+	RegisterPluralSpec([]string{"ksh"}, &PluralSpec{
 		Plurals: newPluralSet(Zero, One, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 0
@@ -194,7 +194,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"iu", "kw", "naq", "se", "sma", "smi", "smj", "smn", "sms"}, &PluralSpec{
+	RegisterPluralSpec([]string{"iu", "kw", "naq", "se", "sma", "smi", "smj", "smn", "sms"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 1
@@ -208,7 +208,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"shi"}, &PluralSpec{
+	RegisterPluralSpec([]string{"shi"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// i = 0 or n = 1
@@ -223,7 +223,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"mo", "ro"}, &PluralSpec{
+	RegisterPluralSpec([]string{"mo", "ro"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// i = 1 and v = 0
@@ -239,7 +239,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"bs", "hr", "sh", "sr"}, &PluralSpec{
+	RegisterPluralSpec([]string{"bs", "hr", "sh", "sr"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// v = 0 and i % 10 = 1 and i % 100 != 11 or f % 10 = 1 and f % 100 != 11
@@ -255,7 +255,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"gd"}, &PluralSpec{
+	RegisterPluralSpec([]string{"gd"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Few, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 1,11
@@ -273,7 +273,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"sl"}, &PluralSpec{
+	RegisterPluralSpec([]string{"sl"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Few, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// v = 0 and i % 100 = 1
@@ -292,7 +292,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"dsb", "hsb"}, &PluralSpec{
+	RegisterPluralSpec([]string{"dsb", "hsb"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Few, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// v = 0 and i % 100 = 1 or f % 100 = 1
@@ -313,7 +313,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"he", "iw"}, &PluralSpec{
+	RegisterPluralSpec([]string{"he", "iw"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Many, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// i = 1 and v = 0
@@ -331,7 +331,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"cs", "sk"}, &PluralSpec{
+	RegisterPluralSpec([]string{"cs", "sk"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Many, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// i = 1 and v = 0
@@ -349,7 +349,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"pl"}, &PluralSpec{
+	RegisterPluralSpec([]string{"pl"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Many, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// i = 1 and v = 0
@@ -369,7 +369,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"be"}, &PluralSpec{
+	RegisterPluralSpec([]string{"be"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Many, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n % 10 = 1 and n % 100 != 11
@@ -389,7 +389,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"lt"}, &PluralSpec{
+	RegisterPluralSpec([]string{"lt"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Many, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n % 10 = 1 and n % 100 != 11..19
@@ -407,7 +407,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"mt"}, &PluralSpec{
+	RegisterPluralSpec([]string{"mt"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Many, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 1
@@ -426,7 +426,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"ru", "uk"}, &PluralSpec{
+	RegisterPluralSpec([]string{"ru", "uk"}, &PluralSpec{
 		Plurals: newPluralSet(One, Few, Many, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// v = 0 and i % 10 = 1 and i % 100 != 11
@@ -446,7 +446,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"br"}, &PluralSpec{
+	RegisterPluralSpec([]string{"br"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Few, Many, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n % 10 = 1 and n % 100 != 11,71,91
@@ -468,7 +468,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"ga"}, &PluralSpec{
+	RegisterPluralSpec([]string{"ga"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Few, Many, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 1
@@ -490,7 +490,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"gv"}, &PluralSpec{
+	RegisterPluralSpec([]string{"gv"}, &PluralSpec{
 		Plurals: newPluralSet(One, Two, Few, Many, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// v = 0 and i % 10 = 1
@@ -512,7 +512,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"ar"}, &PluralSpec{
+	RegisterPluralSpec([]string{"ar"}, &PluralSpec{
 		Plurals: newPluralSet(Zero, One, Two, Few, Many, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 0
@@ -538,7 +538,7 @@ func init() {
 			return Other
 		},
 	})
-	registerPluralSpec([]string{"cy"}, &PluralSpec{
+	RegisterPluralSpec([]string{"cy"}, &PluralSpec{
 		Plurals: newPluralSet(Zero, One, Two, Few, Many, Other),
 		PluralFunc: func(ops *operands) Plural {
 			// n = 0


### PR DESCRIPTION
Fix #72 

The example of registering PluralSpec of unknown language:
```go
filename := "dk.yaml"
langs := language.Parse(filename)
if len(langs) == 0 {
    tags := language.AllLanguageTags(filename)
    if len(tags) == 0 {
        panic("no languages found in " + filename)
    }
    language.RegisterPluralSpec(tags[0], language.EmptyPluralSpec)
}
i18n.MustLoadTranslationFile(filename)
```

/cc @nicksnyder @bep