### PR TITLE
Export GetPluralSpec

### DIFF
--- a/i18n/language/language.go
+++ b/i18n/language/language.go
@@ -45,7 +45,7 @@ func Parse(src string) []*Language {
 		switch chr {
 		case ',', ';', '.':
 			tag := strings.TrimSpace(src[start:end])
-			if spec := getPluralSpec(tag); spec != nil {
+			if spec := GetPluralSpec(tag); spec != nil {
 				langs = append(langs, &Language{NormalizeTag(tag), spec})
 			}
 			start = end + 1
@@ -53,12 +53,12 @@ func Parse(src string) []*Language {
 	}
 	if start > 0 {
 		tag := strings.TrimSpace(src[start:])
-		if spec := getPluralSpec(tag); spec != nil {
+		if spec := GetPluralSpec(tag); spec != nil {
 			langs = append(langs, &Language{NormalizeTag(tag), spec})
 		}
 		return dedupe(langs)
 	}
-	if spec := getPluralSpec(src); spec != nil {
+	if spec := GetPluralSpec(src); spec != nil {
 		langs = append(langs, &Language{NormalizeTag(src), spec})
 	}
 	return langs

--- a/i18n/language/pluralspec.go
+++ b/i18n/language/pluralspec.go
@@ -36,9 +36,9 @@ func (ps *PluralSpec) Plural(number interface{}) (Plural, error) {
 	return ps.PluralFunc(ops), nil
 }
 
-// getPluralSpec returns the PluralSpec that matches the longest prefix of tag.
+// GetPluralSpec returns the PluralSpec that matches the longest prefix of tag.
 // It returns nil if no PluralSpec matches tag.
-func getPluralSpec(tag string) *PluralSpec {
+func GetPluralSpec(tag string) *PluralSpec {
 	tag = NormalizeTag(tag)
 	subtag := tag
 	for {

--- a/i18n/language/pluralspec_test.go
+++ b/i18n/language/pluralspec_test.go
@@ -68,7 +68,7 @@ func TestGetPluralSpec(t *testing.T) {
 		{"xx", nil},
 	}
 	for _, test := range tests {
-		spec := getPluralSpec(test.src)
+		spec := GetPluralSpec(test.src)
 		if spec != test.spec {
 			t.Errorf("getPluralSpec(%q) = %q expected %q", test.src, spec, test.spec)
 		}


### PR DESCRIPTION
This is a follow up to this long-lived Hugo issue:

https://github.com/gohugoio/hugo/issues/3564

This may be improved on in #82 -- but this one is needed just go get it done.

The plan for Hugo's part is:

For all the language codes in use:

1. Check if it is already registered (`GetPluralSpec`)
2. If not, register it as an alias to `GetPluralSpec("en")`