### PR TITLE
Make tests pass with go1.10

### DIFF
--- a/i18n/language/pluralspec_test.go
+++ b/i18n/language/pluralspec_test.go
@@ -70,7 +70,7 @@ func TestGetPluralSpec(t *testing.T) {
 	for _, test := range tests {
 		spec := GetPluralSpec(test.src)
 		if spec != test.spec {
-			t.Errorf("getPluralSpec(%q) = %q expected %q", test.src, spec, test.spec)
+			t.Errorf("getPluralSpec(%v) = %v expected %v", test.src, spec, test.spec)
 		}
 	}
 }

--- a/i18n/translations_test.go
+++ b/i18n/translations_test.go
@@ -63,7 +63,7 @@ func testFile(t *testing.T, path string) {
 
 		got := T(tc.id, args...)
 		if got != tc.want {
-			t.Error("got: %v; want: %v", got, tc.want)
+			t.Errorf("got: %v; want: %v", got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
avoiding following tests failures:

i18n/translations_test.go:66: Error call has possible formatting directive %v
FAIL	_/root/go-i18n/i18n [build failed]
i18n/language/pluralspec_test.go:73: Errorf format %q has arg spec of wrong type *language.PluralSpec
FAIL	_/root/go-i18n/i18n/language [build failed]

more details in Go1.10 upstream release notes https://tip.golang.org/doc/go1.10#test