### PR TITLE
adds ability to define custom funcs in LocalizeConfig #99

### DIFF
--- a/v2/i18n/localizer.go
+++ b/v2/i18n/localizer.go
@@ -3,6 +3,8 @@ package i18n
 import (
 	"fmt"
 
+	"text/template"
+
 	"github.com/nicksnyder/go-i18n/v2/internal"
 	"github.com/nicksnyder/go-i18n/v2/internal/plural"
 	"golang.org/x/text/language"
@@ -56,6 +58,9 @@ type LocalizeConfig struct {
 
 	// DefaultMessage is used if the message is not found in any message files.
 	DefaultMessage *Message
+
+	// Funcs is used to extend the Go template engines built in functions
+	Funcs template.FuncMap
 }
 
 type invalidPluralCountErr struct {
@@ -114,7 +119,7 @@ func (l *Localizer) Localize(lc *LocalizeConfig) (string, error) {
 	if pluralForm == plural.Invalid {
 		return "", &pluralizeErr{messageID: messageID, tag: tag}
 	}
-	return template.Execute(pluralForm, templateData)
+	return template.Execute(pluralForm, templateData, lc.Funcs)
 }
 
 func (l *Localizer) getTemplate(id string, defaultMessage *Message) (language.Tag, *internal.MessageTemplate) {

--- a/v2/internal/message_template.go
+++ b/v2/internal/message_template.go
@@ -3,6 +3,8 @@ package internal
 import (
 	"bytes"
 
+	"text/template"
+
 	"github.com/nicksnyder/go-i18n/v2/internal/plural"
 )
 
@@ -37,9 +39,9 @@ func setPluralTemplate(pluralTemplates map[plural.Form]*Template, pluralForm plu
 }
 
 // Execute executes the template for the plural form and template data.
-func (mt *MessageTemplate) Execute(pluralForm plural.Form, data interface{}) (string, error) {
+func (mt *MessageTemplate) Execute(pluralForm plural.Form, data interface{}, funcs template.FuncMap) (string, error) {
 	t := mt.PluralTemplates[pluralForm]
-	if err := t.parse(mt.LeftDelim, mt.RightDelim); err != nil {
+	if err := t.parse(mt.LeftDelim, mt.RightDelim, funcs); err != nil {
 		return "", err
 	}
 	if t.Template == nil {

--- a/v2/internal/template.go
+++ b/v2/internal/template.go
@@ -12,10 +12,10 @@ type Template struct {
 	ParseErr *error
 }
 
-func (t *Template) parse(leftDelim, rightDelim string) error {
+func (t *Template) parse(leftDelim, rightDelim string, funcs gotemplate.FuncMap) error {
 	if t.ParseErr == nil {
 		if strings.Contains(t.Src, leftDelim) {
-			gt, err := gotemplate.New("").Delims(leftDelim, rightDelim).Parse(t.Src)
+			gt, err := gotemplate.New("").Funcs(funcs).Delims(leftDelim, rightDelim).Parse(t.Src)
 			t.Template = gt
 			t.ParseErr = &err
 		} else {

--- a/v2/internal/template_test.go
+++ b/v2/internal/template_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestParse(t *testing.T) {
 	tmpl := &Template{Src: "hello"}
-	if err := tmpl.parse("", ""); err != nil {
+	if err := tmpl.parse("", "", nil); err != nil {
 		t.Fatal(err)
 	}
 	if tmpl.ParseErr == nil {
@@ -21,7 +21,7 @@ func TestParse(t *testing.T) {
 func TestParseError(t *testing.T) {
 	expectedErr := fmt.Errorf("expected error")
 	tmpl := &Template{ParseErr: &expectedErr}
-	if err := tmpl.parse("", ""); err != expectedErr {
+	if err := tmpl.parse("", "", nil); err != expectedErr {
 		t.Fatalf("expected %#v; got %#v", expectedErr, err)
 	}
 }

--- a/v2/internal/template_test.go
+++ b/v2/internal/template_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"testing"
+	"text/template"
 )
 
 func TestParse(t *testing.T) {
@@ -23,5 +24,23 @@ func TestParseError(t *testing.T) {
 	tmpl := &Template{ParseErr: &expectedErr}
 	if err := tmpl.parse("", "", nil); err != expectedErr {
 		t.Fatalf("expected %#v; got %#v", expectedErr, err)
+	}
+}
+
+func TestParseWithFunc(t *testing.T) {
+	tmpl := &Template{Src: "hello"}
+	funcs := template.FuncMap{
+		"foo": func() string {
+			return "bar"
+		},
+	}
+	if err := tmpl.parse("", "", funcs); err != nil {
+		t.Fatal(err)
+	}
+	if tmpl.ParseErr == nil {
+		t.Fatal("expected non-nil parse error")
+	}
+	if tmpl.Template == nil {
+		t.Fatal("expected non-nil template")
 	}
 }

--- a/v2/internal/template_test.go
+++ b/v2/internal/template_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 	"text/template"
@@ -42,5 +43,12 @@ func TestParseWithFunc(t *testing.T) {
 	}
 	if tmpl.Template == nil {
 		t.Fatal("expected non-nil template")
+	}
+	var buf bytes.Buffer
+	if tmpl.Template.Execute(&buf, nil) != nil {
+		t.Fatal("expected nil template execute error")
+	}
+	if buf.String() != "bar" {
+		t.Fatalf("expected bar; got %s", buf.String())
 	}
 }

--- a/v2/internal/template_test.go
+++ b/v2/internal/template_test.go
@@ -28,7 +28,7 @@ func TestParseError(t *testing.T) {
 }
 
 func TestParseWithFunc(t *testing.T) {
-	tmpl := &Template{Src: "hello"}
+	tmpl := &Template{Src: "{{foo}}"}
 	funcs := template.FuncMap{
 		"foo": func() string {
 			return "bar"


### PR DESCRIPTION
This PR adds the ability to define custom template engine funcs. It adds a `Funcs` field to the `LocalizeConfig` struct and passes this parameter to `gotemplate.Funcs`.
