### PR TITLE
Remove i18n.NewBundle and use struct initialization instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import "github.com/nicksnyder/go-i18n/v2/i18n"
 Create a Bundle to use for the lifetime of your application.
 
 ```go
-bundle := i18n.NewBundle(language.English)
+bundle := &i18n.Bundle{DefaultLanguage: language.English}
 ```
 
 Create a Localizer to use for a set of language preferences.

--- a/v2/example/main.go
+++ b/v2/example/main.go
@@ -27,7 +27,7 @@ var page = template.Must(template.New("").Parse(`
 `))
 
 func main() {
-	bundle := i18n.NewBundle(language.English)
+	bundle := &i18n.Bundle{DefaultLanguage: language.English}
 	bundle.RegisterUnmarshalFunc("toml", toml.Unmarshal)
 	// No need to load active.en.toml since we are providing default translations.
 	// bundle.MustLoadMessageFile("active.en.toml")

--- a/v2/goi18n/extract_command_test.go
+++ b/v2/goi18n/extract_command_test.go
@@ -50,7 +50,7 @@ func TestExtract(t *testing.T) {
 			import "github.com/nicksnyder/go-i18n/v2/i18n"
 
 			func main() {
-				bundle := i18n.NewBundle()
+				bundle := &i18n.Bundle{}
 				l := i18n.NewLocalizer(bundle, "en")
 				l.Localize(&i18n.LocalizeConfig{MessageID: "Plural ID"})
 			}
@@ -69,7 +69,7 @@ func TestExtract(t *testing.T) {
 			import "github.com/nicksnyder/go-i18n/v2/i18n"
 
 			func main() {
-				bundle := i18n.NewBundle()
+				bundle := &i18n.Bundle{}
 				l := i18n.NewLocalizer(bundle, "en")
 				l.MustLocalize(&i18n.LocalizeConfig{MessageID: "Plural ID"})
 			}

--- a/v2/i18n/bundle_test.go
+++ b/v2/i18n/bundle_test.go
@@ -1,7 +1,6 @@
 package i18n
 
 import (
-	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -34,7 +33,7 @@ var everythingMessage = internal.MustNewMessage(map[string]string{
 })
 
 func TestPseudoLanguage(t *testing.T) {
-	bundle := NewBundle(language.English)
+	bundle := &Bundle{DefaultLanguage: language.English}
 	bundle.RegisterUnmarshalFunc("toml", toml.Unmarshal)
 	expected := "simple simple"
 	bundle.MustParseMessageFileBytes([]byte(`
@@ -52,7 +51,7 @@ simple = "simple simple"
 }
 
 func TestPseudoLanguagePlural(t *testing.T) {
-	bundle := NewBundle(language.English)
+	bundle := &Bundle{DefaultLanguage: language.English}
 	bundle.RegisterUnmarshalFunc("toml", toml.Unmarshal)
 	bundle.MustParseMessageFileBytes([]byte(`
 [everything]
@@ -82,7 +81,6 @@ zero = "zero translation"
 
 func TestJSON(t *testing.T) {
 	var bundle Bundle
-	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
 	bundle.MustParseMessageFileBytes([]byte(`{
 	"simple": "simple translation",
 	"detail": {
@@ -163,7 +161,6 @@ other = "other translation"
 
 func TestV1Format(t *testing.T) {
 	var bundle Bundle
-	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
 	bundle.MustParseMessageFileBytes([]byte(`[
 	{
 		"id": "simple",
@@ -191,7 +188,6 @@ func TestV1Format(t *testing.T) {
 
 func TestV1FlatFormat(t *testing.T) {
 	var bundle Bundle
-	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
 	bundle.MustParseMessageFileBytes([]byte(`{
 	"simple": {
 		"other": "simple translation"

--- a/v2/i18n/doc.go
+++ b/v2/i18n/doc.go
@@ -2,7 +2,7 @@
 // according to a set of locale preferences.
 //
 // Create a Bundle to use for the lifetime of your application.
-//     bundle := i18n.NewBundle(language.English)
+//     bundle := &i18n.Bundle{DefaultLanguage: language.English}
 //
 // Create a Localizer to use for a set of language preferences.
 //     func(w http.ResponseWriter, r *http.Request) {

--- a/v2/i18n/example_test.go
+++ b/v2/i18n/example_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ExampleLocalizer_MustLocalize() {
-	bundle := i18n.NewBundle(language.English)
+	bundle := &i18n.Bundle{DefaultLanguage: language.English}
 	localizer := i18n.NewLocalizer(bundle, "en")
 	fmt.Println(localizer.MustLocalize(&i18n.LocalizeConfig{
 		DefaultMessage: &i18n.Message{
@@ -22,7 +22,7 @@ func ExampleLocalizer_MustLocalize() {
 }
 
 func ExampleLocalizer_MustLocalize_noDefaultMessage() {
-	bundle := i18n.NewBundle(language.English)
+	bundle := &i18n.Bundle{DefaultLanguage: language.English}
 	bundle.RegisterUnmarshalFunc("toml", toml.Unmarshal)
 	bundle.MustParseMessageFileBytes([]byte(`
 HelloWorld = "Hello World!"
@@ -45,7 +45,7 @@ HelloWorld = "Hola Mundo!"
 }
 
 func ExampleLocalizer_MustLocalize_plural() {
-	bundle := i18n.NewBundle(language.English)
+	bundle := &i18n.Bundle{DefaultLanguage: language.English}
 	localizer := i18n.NewLocalizer(bundle, "en")
 	catsMessage := &i18n.Message{
 		ID:    "Cats",
@@ -71,7 +71,7 @@ func ExampleLocalizer_MustLocalize_plural() {
 }
 
 func ExampleLocalizer_MustLocalize_template() {
-	bundle := i18n.NewBundle(language.English)
+	bundle := &i18n.Bundle{DefaultLanguage: language.English}
 	localizer := i18n.NewLocalizer(bundle, "en")
 	helloPersonMessage := &i18n.Message{
 		ID:    "HelloPerson",
@@ -86,7 +86,7 @@ func ExampleLocalizer_MustLocalize_template() {
 }
 
 func ExampleLocalizer_MustLocalize_plural_template() {
-	bundle := i18n.NewBundle(language.English)
+	bundle := &i18n.Bundle{DefaultLanguage: language.English}
 	localizer := i18n.NewLocalizer(bundle, "en")
 	personCatsMessage := &i18n.Message{
 		ID:    "PersonCats",
@@ -124,7 +124,7 @@ func ExampleLocalizer_MustLocalize_plural_template() {
 }
 
 func ExampleLocalizer_MustLocalize_customTemplateDelims() {
-	bundle := i18n.NewBundle(language.English)
+	bundle := &i18n.Bundle{DefaultLanguage: language.English}
 	localizer := i18n.NewLocalizer(bundle, "en")
 	helloPersonMessage := &i18n.Message{
 		ID:         "HelloPerson",

--- a/v2/i18n/localizer.go
+++ b/v2/i18n/localizer.go
@@ -24,6 +24,7 @@ type Localizer struct {
 // in the bundle according to the language preferences in langs.
 // It can parse Accept-Language headers as defined in http://www.ietf.org/rfc/rfc2616.txt.
 func NewLocalizer(bundle *Bundle, langs ...string) *Localizer {
+	bundle.init()
 	return &Localizer{
 		bundle: bundle,
 		tags:   parseTags(langs),
@@ -129,7 +130,7 @@ func (l *Localizer) getTemplate(id string, defaultMessage *Message) (language.Ta
 	if template != nil {
 		return fastTag, template
 	}
-	if fastTag == l.bundle.defaultTag {
+	if fastTag == l.bundle.DefaultLanguage {
 		if defaultMessage == nil {
 			return fastTag, nil
 		}
@@ -141,8 +142,8 @@ func (l *Localizer) getTemplate(id string, defaultMessage *Message) (language.Ta
 		// so we need to create a new matcher that contains only the tags in the bundle
 		// that have this message.
 		foundTags := make([]language.Tag, 0, len(l.bundle.messageTemplates))
-		if l.bundle.defaultTag != fastTag {
-			foundTags = append(foundTags, l.bundle.defaultTag)
+		if l.bundle.DefaultLanguage != fastTag {
+			foundTags = append(foundTags, l.bundle.DefaultLanguage)
 		}
 		for t, templates := range l.bundle.messageTemplates {
 			if t == fastTag {
@@ -161,9 +162,9 @@ func (l *Localizer) getTemplate(id string, defaultMessage *Message) (language.Ta
 		}
 	}
 	if defaultMessage == nil {
-		return l.bundle.defaultTag, nil
+		return l.bundle.DefaultLanguage, nil
 	}
-	return l.bundle.defaultTag, internal.NewMessageTemplate(defaultMessage)
+	return l.bundle.DefaultLanguage, internal.NewMessageTemplate(defaultMessage)
 }
 
 func (l *Localizer) matchTemplate(id string, matcher language.Matcher, tags []language.Tag) (language.Tag, *internal.MessageTemplate) {

--- a/v2/i18n/localizer_test.go
+++ b/v2/i18n/localizer_test.go
@@ -476,7 +476,7 @@ func TestLocalizer_Localize(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			bundle := NewBundle(testCase.defaultLanguage)
+			bundle := &Bundle{DefaultLanguage: testCase.defaultLanguage}
 			for tag, messages := range testCase.messages {
 				bundle.AddMessages(tag, messages...)
 			}

--- a/v2/internal/parse.go
+++ b/v2/internal/parse.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -30,12 +31,13 @@ func ParseMessageFileBytes(buf []byte, path string, unmarshalFuncs map[string]Un
 	if len(buf) == 0 {
 		return messageFile, nil
 	}
-	var unmarshalFunc UnmarshalFunc
-	if unmarshalFuncs != nil {
-		unmarshalFunc = unmarshalFuncs[messageFile.Format]
-	}
+	unmarshalFunc := unmarshalFuncs[messageFile.Format]
 	if unmarshalFunc == nil {
-		return nil, fmt.Errorf("no unmarshaler registered for %s", messageFile.Format)
+		if messageFile.Format == "json" {
+			unmarshalFunc = json.Unmarshal
+		} else {
+			return nil, fmt.Errorf("no unmarshaler registered for %s", messageFile.Format)
+		}
 	}
 	var raw interface{}
 	if err := unmarshalFunc(buf, &raw); err != nil {

--- a/v2/internal/parse_test.go
+++ b/v2/internal/parse_test.go
@@ -1,0 +1,50 @@
+package internal
+
+import (
+	"reflect"
+	"testing"
+
+	"golang.org/x/text/language"
+)
+
+func TestParseMessageFileBytes(t *testing.T) {
+	testCases := []struct {
+		file           string
+		path           string
+		unmarshalFuncs map[string]UnmarshalFunc
+		messageFile    *MessageFile
+		err            error
+	}{
+		{
+			file: `{"hello": "world"}`,
+			path: "en.json",
+			messageFile: &MessageFile{
+				Path:   "en.json",
+				Tag:    language.English,
+				Format: "json",
+				Messages: []*Message{{
+					ID:    "hello",
+					Other: "world",
+				}},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		actual, err := ParseMessageFileBytes([]byte(testCase.file), testCase.path, testCase.unmarshalFuncs)
+		if err != testCase.err {
+			t.Fatalf("expected error %#v; got %#v", testCase.err, err)
+		}
+		if actual.Path != testCase.messageFile.Path {
+			t.Fatalf("expected path %q; got %q", testCase.messageFile.Path, actual.Path)
+		}
+		if actual.Tag != testCase.messageFile.Tag {
+			t.Fatalf("expected tag %q; got %q", testCase.messageFile.Tag, actual.Tag)
+		}
+		if actual.Format != testCase.messageFile.Format {
+			t.Fatalf("expected format %q; got %q", testCase.messageFile.Format, actual.Format)
+		}
+		if !reflect.DeepEqual(actual.Messages, testCase.messageFile.Messages) {
+			t.Fatalf("expected %#v; got %#v", testCase.messageFile.Messages, actual.Messages)
+		}
+	}
+}


### PR DESCRIPTION
The goal of this PR is to make initializing a new bundle more readable at the call site.

By using struct initialization, it is obvious what `language.English` means (the default language) without having to look at the docs.

This also makes it easier to evolve the API in the future to add more options without making backward incompatible changes to NewBundle (i.e. adding new parameters).

This breaking change is allowed because 2.0 is still in beta.