### PR TITLE
hotfix: Update outdated v2/go.mod

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,7 +1,7 @@
-module "github.com/nicksnyder/go-i18n/v2"
+module github.com/nicksnyder/go-i18n/v2
 
 require (
-	"github.com/BurntSushi/toml" v0.3.0
-	"golang.org/x/text" v0.0.0-20171214130843-f21a4dfb5e38
-	"gopkg.in/yaml.v2" v1.2.1-gopkgin-v2.2.1
+	github.com/BurntSushi/toml v0.3.0
+	golang.org/x/text v0.0.0-20171214130843-f21a4dfb5e38
+	gopkg.in/yaml.v2 v2.2.1
 )


### PR DESCRIPTION
Hey Nick!
This PR is to update `v2/go.mod`.  

This issue is related to  https://github.com/nicksnyder/go-i18n/issues/116. Apparently `/v2` is  missed out from the update you did previously :) 