### PR TITLE
Fixed localizer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ localizer.MustLocalize(&i18n.LocalizeConfig{
         One: "{{.Name}} has {{.Count}} cat.",
         Other: "{{.Name}} has {{.Count}} cats.",
     },
-    TemplateData: map[string]interface{
+    TemplateData: map[string]interface{}{
         "Name": "Nick",
         "Count": 2,
     },

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ localizer.MustLocalize(&i18n.LocalizeConfig{
         One: "{{.Name}} has {{.Count}} cat.",
         Other: "{{.Name}} has {{.Count}} cats.",
     },
-    TemplateData: map[string]string{
+    TemplateData: map[string]interface{
         "Name": "Nick",
         "Count": 2,
     },


### PR DESCRIPTION
Type for `TemplateData` should be `map[string]interface`, because the value for `Count` is integer