### PR TITLE
Added a check to fix a nil pointer crash

### DIFF
--- a/i18n/translation/single_translation.go
+++ b/i18n/translation/single_translation.go
@@ -38,7 +38,9 @@ func (st *singleTranslation) Normalize(language *language.Language) Translation 
 
 func (st *singleTranslation) Backfill(src Translation) Translation {
 	if (st.template == nil || st.template.src == "") && src != nil {
-		st.template = src.Template(language.Other)
+		if src != nil {
+			st.template = src.Template(language.Other)
+		}
 	}
 	return st
 }


### PR DESCRIPTION
`goi18n merge *.json` causes a panic under some circumstances, because of a nil pointer in `singleTranslation.BackFill.` I added a check for a nil pointer to avoid this.