### PR TITLE
add .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+# https://github.com/golangci/golangci/wiki/Configuration
+
+service:
+  prepare:
+    - go get -t ./...


### PR DESCRIPTION
This pull request fixes warning on fetching dependencies in [golangci.com](https://golangci.com/r/github.com/nicksnyder/go-i18n) analysis