### PR TITLE
Provide nice output of plural form not found error

### DIFF
--- a/v2/internal/message_template.go
+++ b/v2/internal/message_template.go
@@ -39,13 +39,23 @@ func setPluralTemplate(pluralTemplates map[plural.Form]*Template, pluralForm plu
 	}
 }
 
+type pluralFormNotFoundError struct {
+	pluralForm plural.Form
+	messageID  string
+}
+
+func (e pluralFormNotFoundError) Error() string {
+	return fmt.Sprintf("message %q has no plural form %q", e.messageID, e.pluralForm)
+}
+
 // Execute executes the template for the plural form and template data.
 func (mt *MessageTemplate) Execute(pluralForm plural.Form, data interface{}, funcs template.FuncMap) (string, error) {
 	t := mt.PluralTemplates[pluralForm]
-	// check that plural form is found, otherwise return error
 	if t == nil {
-		err := fmt.Errorf("message \"%s\" has no plural form \"%s\" defined", mt.Message.ID, pluralForm)
-		return "", err
+		return "", pluralFormNotFoundError{
+			pluralForm: pluralForm,
+			messageID:  mt.Message.ID,
+		}
 	}
 	if err := t.parse(mt.LeftDelim, mt.RightDelim, funcs); err != nil {
 		return "", err

--- a/v2/internal/message_template.go
+++ b/v2/internal/message_template.go
@@ -42,6 +42,7 @@ func setPluralTemplate(pluralTemplates map[plural.Form]*Template, pluralForm plu
 // Execute executes the template for the plural form and template data.
 func (mt *MessageTemplate) Execute(pluralForm plural.Form, data interface{}, funcs template.FuncMap) (string, error) {
 	t := mt.PluralTemplates[pluralForm]
+	// check that plural form is found, otherwise return error
 	if t == nil {
 		err := fmt.Errorf("message \"%s\" has no plural form \"%s\" defined", mt.Message.ID, pluralForm)
 		return "", err

--- a/v2/internal/message_template.go
+++ b/v2/internal/message_template.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"fmt"
 
 	"text/template"
 
@@ -41,6 +42,10 @@ func setPluralTemplate(pluralTemplates map[plural.Form]*Template, pluralForm plu
 // Execute executes the template for the plural form and template data.
 func (mt *MessageTemplate) Execute(pluralForm plural.Form, data interface{}, funcs template.FuncMap) (string, error) {
 	t := mt.PluralTemplates[pluralForm]
+	if t == nil {
+		err := fmt.Errorf("message \"%s\" has no plural form \"%s\" defined", mt.Message.ID, pluralForm)
+		return "", err
+	}
 	if err := t.parse(mt.LeftDelim, mt.RightDelim, funcs); err != nil {
 		return "", err
 	}

--- a/v2/internal/message_template_test.go
+++ b/v2/internal/message_template_test.go
@@ -1,7 +1,7 @@
 package internal
 
 import (
-	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/nicksnyder/go-i18n/v2/internal/plural"
@@ -20,14 +20,14 @@ func TestNilMessageTemplate(t *testing.T) {
 	}
 }
 
-func TestMessageTemplatePluralFormMissed(t *testing.T) {
-	// test special case when appropriate plural form is not defined
-	mt := NewMessageTemplate(&Message{ID: "MissPluralForm", One: "Hello World", Other: "Hello World"})
-	// this plural form is not defined in NewMessageTemplate call
-	var undefined plural.Form = plural.Few
-	// it's OK to receive error on Execute exit, otherwise, one way or another, raise panic
-	_, err := mt.Execute(undefined, nil, nil)
-	if err == nil {
-		panic(fmt.Sprintf("Message template %v should return error when search for a %q plural form", mt, undefined))
+func TestMessageTemplatePluralFormMissing(t *testing.T) {
+	mt := NewMessageTemplate(&Message{ID: "HelloWorld", Other: "Hello World"})
+	s, err := mt.Execute(plural.Few, nil, nil)
+	if s != "" {
+		t.Errorf("expected %q; got %q", "", s)
+	}
+	expectedErr := pluralFormNotFoundError{pluralForm: plural.Few, messageID: "HelloWorld"}
+	if !reflect.DeepEqual(err, expectedErr) {
+		t.Errorf("expected error %#v; got %#v", expectedErr, err)
 	}
 }

--- a/v2/internal/message_template_test.go
+++ b/v2/internal/message_template_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/nicksnyder/go-i18n/v2/internal/plural"
@@ -16,5 +17,17 @@ func TestMessageTemplate(t *testing.T) {
 func TestNilMessageTemplate(t *testing.T) {
 	if mt := NewMessageTemplate(&Message{ID: "HelloWorld"}); mt != nil {
 		panic(mt)
+	}
+}
+
+func TestMessageTemplatePluralFormMissed(t *testing.T) {
+	// test special case when appropriate plural form is not defined
+	mt := NewMessageTemplate(&Message{ID: "MissPluralForm", One: "Hello World", Other: "Hello World"})
+	// this plural form is not defined in NewMessageTemplate call
+	var undefined plural.Form = plural.Few
+	// it's OK to receive error on Execute exit, otherwise, one way or another, raise panic
+	_, err := mt.Execute(undefined, nil, nil)
+	if err == nil {
+		panic(fmt.Sprintf("Message template %v should return error when search for a %q plural form", mt, undefined))
 	}
 }


### PR DESCRIPTION
Rational:
------------
If you run code example:
```go
package main

import (
	"fmt"

	"github.com/BurntSushi/toml"
	"github.com/nicksnyder/go-i18n/v2/i18n"
	"golang.org/x/text/language"
)

func main() {
	bundle := &i18n.Bundle{DefaultLanguage: language.English}
	bundle.RegisterUnmarshalFunc("toml", toml.Unmarshal)
	// No need to load active.en.toml since we are providing default translations.

	bundle.ParseMessageFileBytes([]byte(`

[Test1]
one = "One"
other = "Other"

		`),
		"active.en.toml")

	bundle.ParseMessageFileBytes([]byte(`

[Test1]
one = "Один"
other = "Другой"
#few = "Несколько"
#many = "Много"

		`), "active.ru.toml")

	localizer := i18n.NewLocalizer(bundle, "en")
	fmt.Println(fmt.Sprintf("en: %s", localizer.MustLocalize(
		&i18n.LocalizeConfig{MessageID: "Test1", PluralCount: 100})))

	localizer = i18n.NewLocalizer(bundle, "ru")
	fmt.Println(fmt.Sprintf("ru: %s", localizer.MustLocalize(
		&i18n.LocalizeConfig{MessageID: "Test1", PluralCount: 100})))
}
```
You will get output, which looks like a bug:
```bash
en: Other
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x539ba6]

goroutine 1 [running]:
github.com/nicksnyder/go-i18n/v2/internal.(*Template).parse(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5936f4, 0x4)
	/home/ddyakov/Documents/gocode/src/github.com/nicksnyder/go-i18n/v2/internal/template.go:16 +0x26
github.com/nicksnyder/go-i18n/v2/internal.(*MessageTemplate).Execute(0xc00007e7d0, 0x5936f4, 0x4, 0x566ac0, 0xc0000f6840, 0x0, 0x4, 0xc00007e7d0, 0x20, 0x571420)
	/home/ddyakov/Documents/gocode/src/github.com/nicksnyder/go-i18n/v2/internal/message_template.go:44 +0xa2
github.com/nicksnyder/go-i18n/v2/i18n.(*Localizer).LocalizeWithTag(0xc0000894a0, 0xc0000cbf08, 0x20, 0x571420, 0xc000089401, 0xc0000894a0, 0xc0000cbe08, 0x53b30f, 0x571420)
	/home/ddyakov/Documents/gocode/src/github.com/nicksnyder/go-i18n/v2/i18n/localizer.go:142 +0x3c2
github.com/nicksnyder/go-i18n/v2/i18n.(*Localizer).Localize(0xc0000894a0, 0xc0000cbf08, 0x1, 0x1, 0x1, 0xc000089480)
	/home/ddyakov/Documents/gocode/src/github.com/nicksnyder/go-i18n/v2/i18n/localizer.go:106 +0x35
github.com/nicksnyder/go-i18n/v2/i18n.(*Localizer).MustLocalize(0xc0000894a0, 0xc0000cbf08, 0x1, 0x1)
	/home/ddyakov/Documents/gocode/src/github.com/nicksnyder/go-i18n/v2/i18n/localizer.go:205 +0x35
main.main()
	/home/ddyakov/Documents/gocode/src/github.com/nicksnyder/go-i18n/v2/example2/main.go:40 +0x456
exit status 2
```
Fix proposed by me resolve this and gives nice output (easy to understand what plural form is missed):
```bash
en: Other
panic: message "Test1" has no plural form "many" defined

goroutine 1 [running]:
github.com/nicksnyder/go-i18n/v2/i18n.(*Localizer).MustLocalize(0xc00000b500, 0xc0000b5f08, 0x1, 0x1)
	/home/ddyakov/Documents/gocode/src/github.com/nicksnyder/go-i18n/v2/i18n/localizer.go:207 +0x79
main.main()
	/home/ddyakov/Documents/gocode/src/github.com/nicksnyder/go-i18n/v2/example2/main.go:40 +0x456
exit status 2
```