### PR TITLE
Fall back to an 'other' plural lookup before giving up

### DIFF
--- a/i18n/bundle/bundle.go
+++ b/i18n/bundle/bundle.go
@@ -380,7 +380,16 @@ func (b *Bundle) translate(lang *language.Language, translationID string, args .
 	p, _ := lang.Plural(count)
 	template := translation.Template(p)
 	if template == nil {
-		return translationID
+		if p == language.Other {
+			return translationID
+		}
+		countInt, ok := count.(int)
+		if ok && countInt > 1 {
+			template = translation.Template(language.Other)
+			if template == nil {
+				return translationID
+			}
+		}
 	}
 
 	s := template.Execute(data)


### PR DESCRIPTION
This change alters the v1 behavior so that plural lookups where
the plural count is greater than 1, but no translation is found,
will attempt another translation with 'other' before falling back
to the default language. This will only happen if the first
translation attempt was not 'other' to begin with.

The reasoning here is that this behavior should be preferable
in most instances instead of resorting to a different language
immediately.

Edit: if this sort of behavior is desirable to merge then I will
address the failing tests.