### PR TITLE
update to CLDR v35.1 (2019-04-17)

### DIFF
--- a/v2/internal/plural/codegen/plurals.xml
+++ b/v2/internal/plural/codegen/plurals.xml
@@ -6,7 +6,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 For terms of use, see http://www.unicode.org/copyright.html
 -->
 <supplementalData>
-    <version number="$Revision: 14397 $"/>
+    <version number="$Revision: 14885 $"/>
     <plurals type="cardinal">
         <!-- For a canonicalized list, use GeneratedPluralSamples -->
 
@@ -18,7 +18,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 
         <!-- 2: one,other -->
 
-        <pluralRules locales="am as bn fa gu hi kn mr zu">
+        <pluralRules locales="am as bn fa gu hi kn zu">
             <pluralRule count="one">i = 0 or n = 1 @integer 0, 1 @decimal 0.0~1.0, 0.00~0.04</pluralRule>
             <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 1.1~2.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
@@ -46,7 +46,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="one">n = 0..1 or n = 11..99 @integer 0, 1, 11~24 @decimal 0.0, 1.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0</pluralRule>
             <pluralRule count="other"> @integer 2~10, 100~106, 1000, 10000, 100000, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
-        <pluralRules locales="af asa az bem bez bg brx ce cgg chr ckb dv ee el eo es eu fo fur gsw ha haw hu jgo jmc ka kaj kcg kk kkj kl ks ksb ku ky lb lg mas mgo ml mn nah nb nd ne nn nnh no nr ny nyn om or os pap ps rm rof rwk saq sd sdh seh sn so sq ss ssy st syr ta te teo tig tk tn tr ts ug uz ve vo vun wae xh xog">
+        <pluralRules locales="af asa az bem bez bg brx ce cgg chr ckb dv ee el eo es eu fo fur gsw ha haw hu jgo jmc ka kaj kcg kk kkj kl ks ksb ku ky lb lg mas mgo ml mn mr nah nb nd ne nn nnh no nr ny nyn om or os pap ps rm rof rwk saq sd sdh seh sn so sq ss ssy st syr ta te teo tig tk tn tr ts ug uz ve vo vun wae xh xog">
             <pluralRule count="one">n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000</pluralRule>
             <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~0.9, 1.1~1.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
@@ -62,7 +62,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="one">v = 0 and i % 10 = 1 and i % 100 != 11 or f % 10 = 1 and f % 100 != 11 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, … @decimal 0.1, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 10.1, 100.1, 1000.1, …</pluralRule>
             <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0, 0.2~1.0, 1.2~1.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
-        <pluralRules locales="fil tl">
+        <pluralRules locales="ceb fil tl">
             <pluralRule count="one">v = 0 and i = 1,2,3 or v = 0 and i % 10 != 4,6,9 or v != 0 and f % 10 != 4,6,9 @integer 0~3, 5, 7, 8, 10~13, 15, 17, 18, 20, 21, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~0.3, 0.5, 0.7, 0.8, 1.0~1.3, 1.5, 1.7, 1.8, 2.0, 2.1, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
             <pluralRule count="other"> @integer 4, 6, 9, 14, 16, 19, 24, 26, 104, 1004, … @decimal 0.4, 0.6, 0.9, 1.4, 1.6, 1.9, 2.4, 2.6, 10.4, 100.4, 1000.4, …</pluralRule>
         </pluralRules>
@@ -87,7 +87,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 
         <!-- 3: one,two,other -->
 
-        <pluralRules locales="iu kw naq se sma smi smj smn sms">
+        <pluralRules locales="iu naq se sma smi smj smn sms">
             <pluralRule count="one">n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000</pluralRule>
             <pluralRule count="two">n = 2 @integer 2 @decimal 2.0, 2.00, 2.000, 2.0000</pluralRule>
             <pluralRule count="other"> @integer 0, 3~17, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~0.9, 1.1~1.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
@@ -102,7 +102,7 @@ For terms of use, see http://www.unicode.org/copyright.html
         </pluralRules>
         <pluralRules locales="mo ro">
             <pluralRule count="one">i = 1 and v = 0 @integer 1</pluralRule>
-            <pluralRule count="few">v != 0 or n = 0 or n != 1 and n % 100 = 1..19 @integer 0, 2~16, 101, 1001, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
+            <pluralRule count="few">v != 0 or n = 0 or n % 100 = 2..19 @integer 0, 2~16, 102, 1002, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
             <pluralRule count="other"> @integer 20~35, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
         </pluralRules>
         <pluralRules locales="bs hr sh sr">
@@ -221,6 +221,14 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="few">n = 3 @integer 3 @decimal 3.0, 3.00, 3.000, 3.0000</pluralRule>
             <pluralRule count="many">n = 6 @integer 6 @decimal 6.0, 6.00, 6.000, 6.0000</pluralRule>
             <pluralRule count="other"> @integer 4, 5, 7~20, 100, 1000, 10000, 100000, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
+        </pluralRules>
+        <pluralRules locales="kw">
+            <pluralRule count="zero">n = 0 @integer 0 @decimal 0.0, 0.00, 0.000, 0.0000</pluralRule>
+            <pluralRule count="one">n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000</pluralRule>
+            <pluralRule count="two">n % 100 = 2,22,42,62,82 or n%1000 = 0 and n%100000=1000..20000,40000,60000,80000 or n!=0 and n%1000000=100000@integer 2, 22, 42, 62, 82, 102, 122, 142, 1002, … @decimal 2.0, 22.0, 42.0, 62.0, 82.0, 102.0, 122.0, 142.0, 1002.0, …</pluralRule>
+            <pluralRule count="few">n % 100 = 3,23,43,63,83 @integer 3, 23, 43, 63, 83, 103, 123, 143, 1003, … @decimal 3.0, 23.0, 43.0, 63.0, 83.0, 103.0, 123.0, 143.0, 1003.0, …</pluralRule>
+            <pluralRule count="many">n != 1 and n % 100 = 1,21,41,61,81 @integer 21, 41, 61, 81, 101, 121, 141, 161, 1001, … @decimal 21.0, 41.0, 61.0, 81.0, 101.0, 121.0, 141.0, 161.0, 1001.0, …</pluralRule>
+            <pluralRule count="other"> @integer 4~19, 100, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
     </plurals>
 </supplementalData>

--- a/v2/internal/plural/codegen/plurals.xml
+++ b/v2/internal/plural/codegen/plurals.xml
@@ -228,7 +228,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <pluralRule count="two">n % 100 = 2,22,42,62,82 or n%1000 = 0 and n%100000=1000..20000,40000,60000,80000 or n!=0 and n%1000000=100000@integer 2, 22, 42, 62, 82, 102, 122, 142, 1002, … @decimal 2.0, 22.0, 42.0, 62.0, 82.0, 102.0, 122.0, 142.0, 1002.0, …</pluralRule>
             <pluralRule count="few">n % 100 = 3,23,43,63,83 @integer 3, 23, 43, 63, 83, 103, 123, 143, 1003, … @decimal 3.0, 23.0, 43.0, 63.0, 83.0, 103.0, 123.0, 143.0, 1003.0, …</pluralRule>
             <pluralRule count="many">n != 1 and n % 100 = 1,21,41,61,81 @integer 21, 41, 61, 81, 101, 121, 141, 161, 1001, … @decimal 21.0, 41.0, 61.0, 81.0, 101.0, 121.0, 141.0, 161.0, 1001.0, …</pluralRule>
-            <pluralRule count="other"> @integer 4~19, 100, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
+            <pluralRule count="other"> @integer 4~19, 100, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.0, 100.0, 1000000.0, …</pluralRule>
         </pluralRules>
     </plurals>
 </supplementalData>

--- a/v2/internal/plural/codegen/xml.go
+++ b/v2/internal/plural/codegen/xml.go
@@ -76,7 +76,7 @@ func (pr *PluralRule) DecimalExamples() []string {
 	return decimal
 }
 
-var relationRegexp = regexp.MustCompile("([niftvw])(?: % ([0-9]+))? (!=|=)(.*)")
+var relationRegexp = regexp.MustCompile(`([niftvw])(?:\s*%\s*([0-9]+))?\s*(!=|=)(.*)`)
 
 // GoCondition converts the XML condition to valid Go code.
 func (pr *PluralRule) GoCondition() string {

--- a/v2/internal/plural/rule_gen.go
+++ b/v2/internal/plural/rule_gen.go
@@ -12,7 +12,7 @@ func DefaultRules() Rules {
 			return Other
 		},
 	})
-	addPluralRules(rules, []string{"am", "as", "bn", "fa", "gu", "hi", "kn", "mr", "zu"}, &Rule{
+	addPluralRules(rules, []string{"am", "as", "bn", "fa", "gu", "hi", "kn", "zu"}, &Rule{
 		PluralForms: newPluralFormSet(One, Other),
 		PluralFormFunc: func(ops *Operands) Form {
 			// i = 0 or n = 1
@@ -85,7 +85,7 @@ func DefaultRules() Rules {
 			return Other
 		},
 	})
-	addPluralRules(rules, []string{"af", "asa", "az", "bem", "bez", "bg", "brx", "ce", "cgg", "chr", "ckb", "dv", "ee", "el", "eo", "es", "eu", "fo", "fur", "gsw", "ha", "haw", "hu", "jgo", "jmc", "ka", "kaj", "kcg", "kk", "kkj", "kl", "ks", "ksb", "ku", "ky", "lb", "lg", "mas", "mgo", "ml", "mn", "nah", "nb", "nd", "ne", "nn", "nnh", "no", "nr", "ny", "nyn", "om", "or", "os", "pap", "ps", "rm", "rof", "rwk", "saq", "sd", "sdh", "seh", "sn", "so", "sq", "ss", "ssy", "st", "syr", "ta", "te", "teo", "tig", "tk", "tn", "tr", "ts", "ug", "uz", "ve", "vo", "vun", "wae", "xh", "xog"}, &Rule{
+	addPluralRules(rules, []string{"af", "asa", "az", "bem", "bez", "bg", "brx", "ce", "cgg", "chr", "ckb", "dv", "ee", "el", "eo", "es", "eu", "fo", "fur", "gsw", "ha", "haw", "hu", "jgo", "jmc", "ka", "kaj", "kcg", "kk", "kkj", "kl", "ks", "ksb", "ku", "ky", "lb", "lg", "mas", "mgo", "ml", "mn", "mr", "nah", "nb", "nd", "ne", "nn", "nnh", "no", "nr", "ny", "nyn", "om", "or", "os", "pap", "ps", "rm", "rof", "rwk", "saq", "sd", "sdh", "seh", "sn", "so", "sq", "ss", "ssy", "st", "syr", "ta", "te", "teo", "tig", "tk", "tn", "tr", "ts", "ug", "uz", "ve", "vo", "vun", "wae", "xh", "xog"}, &Rule{
 		PluralForms: newPluralFormSet(One, Other),
 		PluralFormFunc: func(ops *Operands) Form {
 			// n = 1
@@ -128,7 +128,7 @@ func DefaultRules() Rules {
 			return Other
 		},
 	})
-	addPluralRules(rules, []string{"fil", "tl"}, &Rule{
+	addPluralRules(rules, []string{"ceb", "fil", "tl"}, &Rule{
 		PluralForms: newPluralFormSet(One, Other),
 		PluralFormFunc: func(ops *Operands) Form {
 			// v = 0 and i = 1,2,3 or v = 0 and i % 10 != 4,6,9 or v != 0 and f % 10 != 4,6,9
@@ -186,7 +186,7 @@ func DefaultRules() Rules {
 			return Other
 		},
 	})
-	addPluralRules(rules, []string{"iu", "kw", "naq", "se", "sma", "smi", "smj", "smn", "sms"}, &Rule{
+	addPluralRules(rules, []string{"iu", "naq", "se", "sma", "smi", "smj", "smn", "sms"}, &Rule{
 		PluralForms: newPluralFormSet(One, Two, Other),
 		PluralFormFunc: func(ops *Operands) Form {
 			// n = 1
@@ -222,10 +222,10 @@ func DefaultRules() Rules {
 			if intEqualsAny(ops.I, 1) && intEqualsAny(ops.V, 0) {
 				return One
 			}
-			// v != 0 or n = 0 or n != 1 and n % 100 = 1..19
+			// v != 0 or n = 0 or n % 100 = 2..19
 			if !intEqualsAny(ops.V, 0) ||
 				ops.NEqualsAny(0) ||
-				!ops.NEqualsAny(1) && ops.NModInRange(100, 1, 19) {
+				ops.NModInRange(100, 2, 19) {
 				return Few
 			}
 			return Other
@@ -551,6 +551,34 @@ func DefaultRules() Rules {
 			}
 			// n = 6
 			if ops.NEqualsAny(6) {
+				return Many
+			}
+			return Other
+		},
+	})
+	addPluralRules(rules, []string{"kw"}, &Rule{
+		PluralForms: newPluralFormSet(Zero, One, Two, Few, Many, Other),
+		PluralFormFunc: func(ops *Operands) Form {
+			// n = 0
+			if ops.NEqualsAny(0) {
+				return Zero
+			}
+			// n = 1
+			if ops.NEqualsAny(1) {
+				return One
+			}
+			// n % 100 = 2,22,42,62,82 or n%1000 = 0 and n%100000=1000..20000,40000,60000,80000 or n!=0 and n%1000000=100000
+			if ops.NModEqualsAny(100, 2, 22, 42, 62, 82) ||
+				ops.NModEqualsAny(1000, 0) && (ops.NModInRange(100000, 1000, 20000) || ops.NModEqualsAny(100000, 40000, 60000, 80000)) ||
+				!ops.NEqualsAny(0) && ops.NModEqualsAny(1000000, 100000) {
+				return Two
+			}
+			// n % 100 = 3,23,43,63,83
+			if ops.NModEqualsAny(100, 3, 23, 43, 63, 83) {
+				return Few
+			}
+			// n != 1 and n % 100 = 1,21,41,61,81
+			if !ops.NEqualsAny(1) && ops.NModEqualsAny(100, 1, 21, 41, 61, 81) {
 				return Many
 			}
 			return Other

--- a/v2/internal/plural/rule_gen_test.go
+++ b/v2/internal/plural/rule_gen_test.go
@@ -16,7 +16,7 @@ func TestBmBoDzIdIgIiInJaJboJvJwKdeKeaKmKoLktLoMsMyNqoRootSahSesSgThToViWoYoYueZ
 	}
 }
 
-func TestAmAsBnFaGuHiKnMrZu(t *testing.T) {
+func TestAmAsBnFaGuHiKnZu(t *testing.T) {
 	var tests []pluralFormTest
 
 	tests = appendIntegerTests(tests, One, []string{"0", "1"})
@@ -25,7 +25,7 @@ func TestAmAsBnFaGuHiKnMrZu(t *testing.T) {
 	tests = appendIntegerTests(tests, Other, []string{"2~17", "100", "1000", "10000", "100000", "1000000"})
 	tests = appendDecimalTests(tests, Other, []string{"1.1~2.6", "10.0", "100.0", "1000.0", "10000.0", "100000.0", "1000000.0"})
 
-	locales := []string{"am", "as", "bn", "fa", "gu", "hi", "kn", "mr", "zu"}
+	locales := []string{"am", "as", "bn", "fa", "gu", "hi", "kn", "zu"}
 	for _, locale := range locales {
 		runTests(t, locale, tests)
 	}
@@ -120,7 +120,7 @@ func TestTzm(t *testing.T) {
 	}
 }
 
-func TestAfAsaAzBemBezBgBrxCeCggChrCkbDvEeElEoEsEuFoFurGswHaHawHuJgoJmcKaKajKcgKkKkjKlKsKsbKuKyLbLgMasMgoMlMnNahNbNdNeNnNnhNoNrNyNynOmOrOsPapPsRmRofRwkSaqSdSdhSehSnSoSqSsSsyStSyrTaTeTeoTigTkTnTrTsUgUzVeVoVunWaeXhXog(t *testing.T) {
+func TestAfAsaAzBemBezBgBrxCeCggChrCkbDvEeElEoEsEuFoFurGswHaHawHuJgoJmcKaKajKcgKkKkjKlKsKsbKuKyLbLgMasMgoMlMnMrNahNbNdNeNnNnhNoNrNyNynOmOrOsPapPsRmRofRwkSaqSdSdhSehSnSoSqSsSsyStSyrTaTeTeoTigTkTnTrTsUgUzVeVoVunWaeXhXog(t *testing.T) {
 	var tests []pluralFormTest
 
 	tests = appendIntegerTests(tests, One, []string{"1"})
@@ -129,7 +129,7 @@ func TestAfAsaAzBemBezBgBrxCeCggChrCkbDvEeElEoEsEuFoFurGswHaHawHuJgoJmcKaKajKcgK
 	tests = appendIntegerTests(tests, Other, []string{"0", "2~16", "100", "1000", "10000", "100000", "1000000"})
 	tests = appendDecimalTests(tests, Other, []string{"0.0~0.9", "1.1~1.6", "10.0", "100.0", "1000.0", "10000.0", "100000.0", "1000000.0"})
 
-	locales := []string{"af", "asa", "az", "bem", "bez", "bg", "brx", "ce", "cgg", "chr", "ckb", "dv", "ee", "el", "eo", "es", "eu", "fo", "fur", "gsw", "ha", "haw", "hu", "jgo", "jmc", "ka", "kaj", "kcg", "kk", "kkj", "kl", "ks", "ksb", "ku", "ky", "lb", "lg", "mas", "mgo", "ml", "mn", "nah", "nb", "nd", "ne", "nn", "nnh", "no", "nr", "ny", "nyn", "om", "or", "os", "pap", "ps", "rm", "rof", "rwk", "saq", "sd", "sdh", "seh", "sn", "so", "sq", "ss", "ssy", "st", "syr", "ta", "te", "teo", "tig", "tk", "tn", "tr", "ts", "ug", "uz", "ve", "vo", "vun", "wae", "xh", "xog"}
+	locales := []string{"af", "asa", "az", "bem", "bez", "bg", "brx", "ce", "cgg", "chr", "ckb", "dv", "ee", "el", "eo", "es", "eu", "fo", "fur", "gsw", "ha", "haw", "hu", "jgo", "jmc", "ka", "kaj", "kcg", "kk", "kkj", "kl", "ks", "ksb", "ku", "ky", "lb", "lg", "mas", "mgo", "ml", "mn", "mr", "nah", "nb", "nd", "ne", "nn", "nnh", "no", "nr", "ny", "nyn", "om", "or", "os", "pap", "ps", "rm", "rof", "rwk", "saq", "sd", "sdh", "seh", "sn", "so", "sq", "ss", "ssy", "st", "syr", "ta", "te", "teo", "tig", "tk", "tn", "tr", "ts", "ug", "uz", "ve", "vo", "vun", "wae", "xh", "xog"}
 	for _, locale := range locales {
 		runTests(t, locale, tests)
 	}
@@ -180,7 +180,7 @@ func TestMk(t *testing.T) {
 	}
 }
 
-func TestFilTl(t *testing.T) {
+func TestCebFilTl(t *testing.T) {
 	var tests []pluralFormTest
 
 	tests = appendIntegerTests(tests, One, []string{"0~3", "5", "7", "8", "10~13", "15", "17", "18", "20", "21", "100", "1000", "10000", "100000", "1000000"})
@@ -189,7 +189,7 @@ func TestFilTl(t *testing.T) {
 	tests = appendIntegerTests(tests, Other, []string{"4", "6", "9", "14", "16", "19", "24", "26", "104", "1004"})
 	tests = appendDecimalTests(tests, Other, []string{"0.4", "0.6", "0.9", "1.4", "1.6", "1.9", "2.4", "2.6", "10.4", "100.4", "1000.4"})
 
-	locales := []string{"fil", "tl"}
+	locales := []string{"ceb", "fil", "tl"}
 	for _, locale := range locales {
 		runTests(t, locale, tests)
 	}
@@ -249,7 +249,7 @@ func TestKsh(t *testing.T) {
 	}
 }
 
-func TestIuKwNaqSeSmaSmiSmjSmnSms(t *testing.T) {
+func TestIuNaqSeSmaSmiSmjSmnSms(t *testing.T) {
 	var tests []pluralFormTest
 
 	tests = appendIntegerTests(tests, One, []string{"1"})
@@ -261,7 +261,7 @@ func TestIuKwNaqSeSmaSmiSmjSmnSms(t *testing.T) {
 	tests = appendIntegerTests(tests, Other, []string{"0", "3~17", "100", "1000", "10000", "100000", "1000000"})
 	tests = appendDecimalTests(tests, Other, []string{"0.0~0.9", "1.1~1.6", "10.0", "100.0", "1000.0", "10000.0", "100000.0", "1000000.0"})
 
-	locales := []string{"iu", "kw", "naq", "se", "sma", "smi", "smj", "smn", "sms"}
+	locales := []string{"iu", "naq", "se", "sma", "smi", "smj", "smn", "sms"}
 	for _, locale := range locales {
 		runTests(t, locale, tests)
 	}
@@ -290,7 +290,7 @@ func TestMoRo(t *testing.T) {
 
 	tests = appendIntegerTests(tests, One, []string{"1"})
 
-	tests = appendIntegerTests(tests, Few, []string{"0", "2~16", "101", "1001"})
+	tests = appendIntegerTests(tests, Few, []string{"0", "2~16", "102", "1002"})
 	tests = appendDecimalTests(tests, Few, []string{"0.0~1.5", "10.0", "100.0", "1000.0", "10000.0", "100000.0", "1000000.0"})
 
 	tests = appendIntegerTests(tests, Other, []string{"20~35", "100", "1000", "10000", "100000", "1000000"})
@@ -625,6 +625,33 @@ func TestCy(t *testing.T) {
 	tests = appendDecimalTests(tests, Other, []string{"0.1~0.9", "1.1~1.7", "10.0", "100.0", "1000.0", "10000.0", "100000.0", "1000000.0"})
 
 	locales := []string{"cy"}
+	for _, locale := range locales {
+		runTests(t, locale, tests)
+	}
+}
+
+func TestKw(t *testing.T) {
+	var tests []pluralFormTest
+
+	tests = appendIntegerTests(tests, Zero, []string{"0"})
+	tests = appendDecimalTests(tests, Zero, []string{"0.0", "0.00", "0.000", "0.0000"})
+
+	tests = appendIntegerTests(tests, One, []string{"1"})
+	tests = appendDecimalTests(tests, One, []string{"1.0", "1.00", "1.000", "1.0000"})
+
+	tests = appendIntegerTests(tests, Two, []string{"2", "22", "42", "62", "82", "102", "122", "142", "1002"})
+	tests = appendDecimalTests(tests, Two, []string{"2.0", "22.0", "42.0", "62.0", "82.0", "102.0", "122.0", "142.0", "1002.0"})
+
+	tests = appendIntegerTests(tests, Few, []string{"3", "23", "43", "63", "83", "103", "123", "143", "1003"})
+	tests = appendDecimalTests(tests, Few, []string{"3.0", "23.0", "43.0", "63.0", "83.0", "103.0", "123.0", "143.0", "1003.0"})
+
+	tests = appendIntegerTests(tests, Many, []string{"21", "41", "61", "81", "101", "121", "141", "161", "1001"})
+	tests = appendDecimalTests(tests, Many, []string{"21.0", "41.0", "61.0", "81.0", "101.0", "121.0", "141.0", "161.0", "1001.0"})
+
+	tests = appendIntegerTests(tests, Other, []string{"4~19", "100", "1000000"})
+	tests = appendDecimalTests(tests, Other, []string{"0.1~0.9", "1.1~1.7", "10.0", "100.0", "1000.0", "10000.0", "100000.0", "1000000.0"})
+
+	locales := []string{"kw"}
 	for _, locale := range locales {
 		runTests(t, locale, tests)
 	}

--- a/v2/internal/plural/rule_gen_test.go
+++ b/v2/internal/plural/rule_gen_test.go
@@ -649,7 +649,7 @@ func TestKw(t *testing.T) {
 	tests = appendDecimalTests(tests, Many, []string{"21.0", "41.0", "61.0", "81.0", "101.0", "121.0", "141.0", "161.0", "1001.0"})
 
 	tests = appendIntegerTests(tests, Other, []string{"4~19", "100", "1000000"})
-	tests = appendDecimalTests(tests, Other, []string{"0.1~0.9", "1.1~1.7", "10.0", "100.0", "1000.0", "10000.0", "100000.0", "1000000.0"})
+	tests = appendDecimalTests(tests, Other, []string{"0.1~0.9", "1.1~1.7", "10.0", "100.0", "1000000.0"})
 
 	locales := []string{"kw"}
 	for _, locale := range locales {


### PR DESCRIPTION
The build is broken because the rule for `kw` is inconsistent with the examples. Specifically the rule categorizes "1000.0", "10000.0" and "100000.0" as `two` but these are listed as examples for `other`.

```
--- FAIL: TestKw (0.00s)
    rule_test.go:30: kw: PluralFormFunc(&plural.Operands{N:1000, I:1000, V:1, W:0, F:0, T:0}) returned "two", <nil>; expected "other"
    rule_test.go:30: kw: PluralFormFunc(&plural.Operands{N:10000, I:10000, V:1, W:0, F:0, T:0}) returned "two", <nil>; expected "other"
    rule_test.go:30: kw: PluralFormFunc(&plural.Operands{N:100000, I:100000, V:1, W:0, F:0, T:0}) returned "two", <nil>; expected "other"
```