### PR TITLE
fix(goi18n): could not extract constant message id

### DIFF
--- a/v2/goi18n/extract_command.go
+++ b/v2/goi18n/extract_command.go
@@ -51,16 +51,19 @@ func (ec *extractCommand) name() string {
 	return "extract"
 }
 
-func (ec *extractCommand) parse(args []string) {
+func (ec *extractCommand) parse(args []string) error {
 	flags := flag.NewFlagSet("extract", flag.ExitOnError)
 	flags.Usage = usageExtract
 
 	flags.Var(&ec.sourceLanguage, "sourceLanguage", "en")
 	flags.StringVar(&ec.outdir, "outdir", ".", "")
 	flags.StringVar(&ec.format, "format", "toml", "")
-	flags.Parse(args)
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
 
 	ec.paths = flags.Args()
+	return nil
 }
 
 func (ec *extractCommand) execute() error {

--- a/v2/goi18n/extract_command.go
+++ b/v2/goi18n/extract_command.go
@@ -51,19 +51,16 @@ func (ec *extractCommand) name() string {
 	return "extract"
 }
 
-func (ec *extractCommand) parse(args []string) error {
+func (ec *extractCommand) parse(args []string) {
 	flags := flag.NewFlagSet("extract", flag.ExitOnError)
 	flags.Usage = usageExtract
 
 	flags.Var(&ec.sourceLanguage, "sourceLanguage", "en")
 	flags.StringVar(&ec.outdir, "outdir", ".", "")
 	flags.StringVar(&ec.format, "format", "toml", "")
-	if err := flags.Parse(args); err != nil {
-		return err
-	}
+	flags.Parse(args)
 
 	ec.paths = flags.Args()
-	return nil
 }
 
 func (ec *extractCommand) execute() error {
@@ -258,6 +255,16 @@ func extractStringLiteral(expr ast.Expr) (string, bool) {
 			return "", false
 		}
 		return x + y, true
+	case *ast.Ident:
+		switch z := v.Obj.Decl.(type) {
+		case *ast.ValueSpec:
+			s, ok := extractStringLiteral(z.Values[0])
+			if !ok {
+				return "", false
+			}
+			return s, true
+		}
+		return "", false
 	default:
 		return "", false
 	}

--- a/v2/goi18n/extract_command_test.go
+++ b/v2/goi18n/extract_command_test.go
@@ -186,11 +186,6 @@ zero = "Zero translation"
 			`,
 		},
 		{
-			name:     "id constant",
-			fileName: "file.go",
-			file:     `package main`,
-		},
-		{
 			name:     "global declaration",
 			fileName: "file.go",
 			file: `package main

--- a/v2/goi18n/extract_command_test.go
+++ b/v2/goi18n/extract_command_test.go
@@ -185,6 +185,28 @@ zero = "Zero translation"
 			}
 			`,
 		},
+		{
+			name:     "id constant",
+			fileName: "file.go",
+			file:     `package main`,
+		},
+		{
+			name:     "global declaration",
+			fileName: "file.go",
+			file: `package main
+
+			import "github.com/nicksnyder/go-i18n/v2/i18n"
+
+			const constID = "ConstantID"
+			
+			var m = &i18n.Message{
+				ID: constID,
+				Other: "ID is a constant",
+			}
+			`,
+			activeFile: []byte(`ConstantID = "ID is a constant"
+`),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
If you specified a constant for message id e.g

```
package main

import "github.com/nicksnyder/go-i18n/v2/i18n"

const constID = "ConstantID"
			
var m = &i18n.Message{
    ID: constID,
    Other: "ID is a constant",
}
```

goi18n extract failed with `failed to marshal en strings to toml: toml: Key '' is not a valid table name. Key names cannot be empty.`