### PR TITLE
Fix panic caused by nil pointer dereference in "extract" command

### DIFF
--- a/v2/goi18n/extract_command.go
+++ b/v2/goi18n/extract_command.go
@@ -259,6 +259,9 @@ func extractStringLiteral(expr ast.Expr) (string, bool) {
 		}
 		return x + y, true
 	case *ast.Ident:
+		if v.Obj == nil {
+			return "", false
+		}
 		switch z := v.Obj.Decl.(type) {
 		case *ast.ValueSpec:
 			s, ok := extractStringLiteral(z.Values[0])

--- a/v2/goi18n/extract_command_test.go
+++ b/v2/goi18n/extract_command_test.go
@@ -202,6 +202,18 @@ zero = "Zero translation"
 			activeFile: []byte(`ConstantID = "ID is a constant"
 `),
 		},
+		{
+			name:     "undefined identifier in composite lit",
+			fileName: "file.go",
+			file: `package main
+
+			import "github.com/nicksnyder/go-i18n/v2/i18n"
+
+			var m = &i18n.LocalizeConfig{
+				Funcs: Funcs,
+			}
+			`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes the issue described in #206 (more specifically, [this comment](https://github.com/nicksnyder/go-i18n/issues/206#issuecomment-592581660)).

In short, if an identifier is used inside a composite literal, e.g.
```go
var x = &i18n.LocalizeConfig{
  Funcs: SomeIdentifier,
}
```
and that identifier (in this case, `SomeIdentifier`) is defined in _another file_, the resulting `ast.Ident` will have a nil `Obj` field, which is causing the `goi18n extract` command to panic.

This just adds a simple nil check before accessing the field to prevent the panic from happening.