### PR TITLE
Do not encode HTML entities in JSON message files

### DIFF
--- a/v2/goi18n/marshal.go
+++ b/v2/goi18n/marshal.go
@@ -49,7 +49,12 @@ func marshalValue(messageTemplates map[string]*i18n.MessageTemplate, sourceLangu
 func marshal(v interface{}, format string) ([]byte, error) {
 	switch format {
 	case "json":
-		return json.MarshalIndent(v, "", "  ")
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetEscapeHTML(false)
+		enc.SetIndent("", "  ")
+		err := enc.Encode(v)
+		return buf.Bytes(), err
 	case "toml":
 		var buf bytes.Buffer
 		enc := toml.NewEncoder(&buf)

--- a/v2/goi18n/marshal_test.go
+++ b/v2/goi18n/marshal_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+func TestMarshal(t *testing.T) {
+	actual, err := marshal(map[string]string{
+		"&<key>": "&<val>",
+	}, "json")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `{
+  "&<key>": "&<val>"
+}
+`
+	if a := string(actual); a != expected {
+		t.Fatalf("\nexpected:\n%s\n\ngot\n%s", expected, a)
+	}
+}


### PR DESCRIPTION
There is no reason `<`, `>`, or `&` need to be escaped in message files.

fixes https://github.com/nicksnyder/go-i18n/issues/217