### PR TITLE
fix escape sequences when extracting string literals

### DIFF
--- a/v2/goi18n/extract_command.go
+++ b/v2/goi18n/extract_command.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/nicksnyder/go-i18n/v2/i18n"
@@ -240,9 +241,9 @@ func extractStringLiteral(expr ast.Expr) (string, bool) {
 		if v.Kind != token.STRING {
 			return "", false
 		}
-		s := v.Value[1 : len(v.Value)-1]
-		if v.Value[0] == '"' {
-			s = strings.Replace(s, `\"`, `"`, -1)
+		s, err := strconv.Unquote(v.Value)
+		if err != nil {
+			return "", false
 		}
 		return s, true
 	case *ast.BinaryExpr:

--- a/v2/goi18n/extract_command_test.go
+++ b/v2/goi18n/extract_command_test.go
@@ -34,6 +34,21 @@ func TestExtract(t *testing.T) {
 			`,
 		},
 		{
+			name:     "escape newline",
+			fileName: "file.go",
+			file: `package main
+
+			import "github.com/nicksnyder/go-i18n/v2/i18n"
+
+			var hasnewline = &i18n.Message{
+				ID:    "hasnewline",
+				Other: "\nfoo\nbar\\",
+			}
+			`,
+			activeFile: []byte(`hasnewline = "\nfoo\nbar\\"
+`),
+		},
+		{
 			name:     "escape",
 			fileName: "file.go",
 			file: `package main


### PR DESCRIPTION
fixes https://github.com/nicksnyder/go-i18n/issues/233