### PR TITLE
Add support for loading bundle from fs.FS

### DIFF
--- a/v2/i18n/bundlefs.go
+++ b/v2/i18n/bundlefs.go
@@ -1,0 +1,18 @@
+// +build go1.16
+
+package i18n
+
+import (
+	"io/fs"
+)
+
+// LoadMessageFileFS is like LoadMessageFile but instead of reading from the
+// hosts operating system's file system it reads from the fs file system.
+func (b *Bundle) LoadMessageFileFS(fsys fs.FS, path string) (*MessageFile, error) {
+	buf, err := fs.ReadFile(fsys, path)
+	if err != nil {
+		return nil, err
+	}
+
+	return b.ParseMessageFileBytes(buf, path)
+}


### PR DESCRIPTION
This commit aims to add a method for loading bundles from fs.FS. The
change is done to be able to get a nice way to load bundles from an
embedded file system.

Since this can be done by implementing the exported API and using
ParseMessageFileBytes externally, this is not a change that is a must
have. Rather a nice shorthand for using the fs.FS.

This is how it can be used:

    package main

    import (
            "embed"

            "github.com/nicksnyder/go-i18n/v2/i18n"
    )

    //go:embed locale.*.json
    var LocaleFS embed.FS

    func main() {
            bundle := i18n.NewBundle(language.English)
            bundle.RegisterUnmarshalFunc("json", json.Unmarshal)

            bundle.LoadMessageFileFS(LocaleFS, "locale.sv.json")
    }

Thanks!