### PR TITLE
Update test to new error message in go 1.16

### DIFF
--- a/v2/internal/template_test.go
+++ b/v2/internal/template_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"strings"
 	"testing"
 	"text/template"
 )
@@ -45,7 +46,7 @@ func TestExecute(t *testing.T) {
 			template: &Template{
 				Src: "hello {{",
 			},
-			err:      "template: :1: unclosed action",
+			err:      "unclosed action",
 			noallocs: true,
 		},
 	}
@@ -53,8 +54,8 @@ func TestExecute(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.template.Src, func(t *testing.T) {
 			result, err := test.template.Execute(test.funcs, test.data)
-			if actual := str(err); actual != test.err {
-				t.Errorf("expected err %q; got %q", test.err, actual)
+			if actual := str(err); !strings.Contains(str(err), test.err) {
+				t.Errorf("expected err %q to contain %q", actual, test.err)
 			}
 			if result != test.result {
 				t.Errorf("expected result %q; got %q", test.result, result)

--- a/v2/internal/template_test.go
+++ b/v2/internal/template_test.go
@@ -45,7 +45,7 @@ func TestExecute(t *testing.T) {
 			template: &Template{
 				Src: "hello {{",
 			},
-			err:      "template: :1: unexpected unclosed action in command",
+			err:      "template: :1: unclosed action",
 			noallocs: true,
 		},
 	}


### PR DESCRIPTION
As of go 1.16, the error message in text/template for this specific case has changed.