### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.5
+          go-version: 1.17.7
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Build
@@ -25,15 +25,15 @@ jobs:
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload coverage
         uses: codecov/codecov-action@v1
-  build_1_9_7:
-    name: Build with Go 1.9.7
+  build_1_10:
+    name: Build with Go 1.10.8
     runs-on: ubuntu-latest
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request'
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.9.7
+          go-version: 1.10.8
       - name: Git checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,15 +25,15 @@ jobs:
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload coverage
         uses: codecov/codecov-action@v1
-  build_1_10:
-    name: Build with Go 1.10.8
+  build_1_12:
+    name: Build with Go 1.12.17
     runs-on: ubuntu-latest
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request'
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.10.8
+          go-version: 1.12.17
       - name: Git checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.15.2'
+          go-version: '^1.17.7'
       -
         name: Release
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/lsif-go.yml
+++ b/.github/workflows/lsif-go.yml
@@ -10,5 +10,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Generate LSIF data
         run: lsif-go
+        working-directory: v2
       - name: Upload LSIF data to Sourcegraph.com
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }} -ignore-upload-failure
+        working-directory: v2

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,9 +1,9 @@
 module github.com/nicksnyder/go-i18n/v2
 
-go 1.9
+go 1.10
 
 require (
-	github.com/BurntSushi/toml v0.3.1
+	github.com/BurntSushi/toml v1.0.0
 	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/nicksnyder/go-i18n/v2
 
-go 1.10
+go 1.12
 
 require (
 	github.com/BurntSushi/toml v1.0.0

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -4,6 +4,6 @@ go 1.9
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	golang.org/x/text v0.3.3
+	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,5 +1,5 @@
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
-github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.0.0 h1:dtDWrepsVPfW9H/4y7dDgFc2MBUSeJhlaDtK13CxFlU=
+github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
-golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
- Go from 1.9 to 1.12 (due to BurntSushi/toml).
- github.com/BurntSushi/toml v1.0.0
- golang.org/x/text v0.3.7

Fixes https://github.com/nicksnyder/go-i18n/issues/267