### PR TITLE
doc(localizer): add specification about language tag detection

### DIFF
--- a/v2/i18n/localizer.go
+++ b/v2/i18n/localizer.go
@@ -9,6 +9,15 @@ import (
 )
 
 // Localizer provides Localize and MustLocalize methods that return localized messages.
+// Localize and MustLocalize methods use a language.Tag matching algorithm based
+// on the best possible value. This algorithm may cause an unexpected language.Tag returned
+// value depending on the order of the tags stored in memory. For example, if the bundle
+// used to create a Localizer instance ingested locales following this order
+// ["en-US", "en-GB", "en-IE", "en"] and the locale "en" is asked, the underlying matching
+// algorithm will return "en-US" thinking it is the best match possible. More information
+// about the algorithm in this Github issue: https://github.com/golang/go/issues/49176.
+// There is additionnal informations inside the Go code base:
+// https://github.com/golang/text/blob/master/language/match.go#L142
 type Localizer struct {
 	// bundle contains the messages that can be returned by the Localizer.
 	bundle *Bundle


### PR DESCRIPTION
I've been stumbling across a frustrating issue with the underlying tag detection from `x/text/language.Matcher`: the detection algorithm will return a tag value based on a given score who can be surprising. 

Because it is not a bug, I just updated the documentation of `Localizer` in order to give some hint for future user.

I did two go-playground to show this more specifically https://go.dev/play/p/TMoszzbeEZ2

Here is a link to a related Github issue in x/text/language: https://github.com/golang/go/issues/49176