### PR TITLE
Fix Localize regression with empty default message

### DIFF
--- a/v2/i18n/localizer.go
+++ b/v2/i18n/localizer.go
@@ -190,7 +190,11 @@ func (l *Localizer) getMessageTemplate(id string, defaultMessage *Message) (lang
 		if defaultMessage == nil {
 			return language.Und, nil, &MessageNotFoundErr{tag: tag, messageID: id}
 		}
-		return tag, NewMessageTemplate(defaultMessage), nil
+		mt := NewMessageTemplate(defaultMessage)
+		if mt == nil {
+			return language.Und, nil, &MessageNotFoundErr{tag: tag, messageID: id}
+		}
+		return tag, mt, nil
 	}
 
 	// Fallback to default language in bundle.

--- a/v2/i18n/localizer_test.go
+++ b/v2/i18n/localizer_test.go
@@ -577,6 +577,15 @@ func localizerTests() []localizerTest {
 			},
 			expectedErr: &MessageNotFoundErr{tag: language.AmericanEnglish, messageID: "Hello"},
 		},
+		{
+			name:            "empty default message",
+			defaultLanguage: language.English,
+			acceptLangs:     []string{"en"},
+			conf: &LocalizeConfig{
+				DefaultMessage: &Message{},
+			},
+			expectedErr: &MessageNotFoundErr{tag: language.English, messageID: ""},
+		},
 	}
 }
 

--- a/v2/i18n/localizer_test.go
+++ b/v2/i18n/localizer_test.go
@@ -582,6 +582,15 @@ func localizerTests() []localizerTest {
 			defaultLanguage: language.English,
 			acceptLangs:     []string{"en"},
 			conf: &LocalizeConfig{
+				DefaultMessage: &Message{},
+			},
+			expectedErr: &MessageNotFoundErr{tag: language.English, messageID: ""},
+		},
+		{
+			name:            "empty default message with id",
+			defaultLanguage: language.English,
+			acceptLangs:     []string{"en"},
+			conf: &LocalizeConfig{
 				DefaultMessage: &Message{
 					ID: "Hello",
 				},

--- a/v2/i18n/localizer_test.go
+++ b/v2/i18n/localizer_test.go
@@ -582,9 +582,11 @@ func localizerTests() []localizerTest {
 			defaultLanguage: language.English,
 			acceptLangs:     []string{"en"},
 			conf: &LocalizeConfig{
-				DefaultMessage: &Message{},
+				DefaultMessage: &Message{
+					ID: "Hello",
+				},
 			},
-			expectedErr: &MessageNotFoundErr{tag: language.English, messageID: ""},
+			expectedErr: &MessageNotFoundErr{tag: language.English, messageID: "Hello"},
 		},
 	}
 }


### PR DESCRIPTION
Behavior has changed with #189. Before that, an empty default message returned nil and an error, now it returns "" without error.

This has been detected by mattermost test suit in https://github.com/mattermost/mattermost/pull/21327 which tries to switch all code base to go-i18n v2, see [related discussion](https://github.com/mattermost/mattermost/pull/21327/files#r1365634307)