### PR TITLE
Add option to skip template execution

### DIFF
--- a/v2/i18n/localizer_test.go
+++ b/v2/i18n/localizer_test.go
@@ -348,6 +348,22 @@ func localizerTests() []localizerTest {
 			expectedLocalized: "Hello Nick",
 		},
 		{
+			name:            "ignore template, bundle message",
+			defaultLanguage: language.English,
+			messages: map[language.Tag][]*Message{
+				language.English: {{
+					ID:    "HelloPerson",
+					Other: "Hello {{.Person}}",
+				}},
+			},
+			acceptLangs: []string{"en"},
+			conf: &LocalizeConfig{
+				MessageID:      "HelloPerson",
+				NoTemplateExec: true,
+			},
+			expectedLocalized: "Hello {{.Person}}",
+		},
+		{
 			name:            "template data, default message",
 			defaultLanguage: language.English,
 			acceptLangs:     []string{"en"},

--- a/v2/i18n/message_template.go
+++ b/v2/i18n/message_template.go
@@ -63,3 +63,15 @@ func (mt *MessageTemplate) Execute(pluralForm plural.Form, data interface{}, fun
 	}
 	return t.Execute(funcs, data)
 }
+
+// Get returns unprocessed template string for the plural form.
+func (mt *MessageTemplate) Get(pluralForm plural.Form) (string, error) {
+	t := mt.PluralTemplates[pluralForm]
+	if t == nil {
+		return "", pluralFormNotFoundError{
+			pluralForm: pluralForm,
+			messageID:  mt.Message.ID,
+		}
+	}
+	return t.Src, nil
+}

--- a/v2/i18n/message_template_test.go
+++ b/v2/i18n/message_template_test.go
@@ -31,3 +31,15 @@ func TestMessageTemplatePluralFormMissing(t *testing.T) {
 		t.Errorf("expected error %#v; got %#v", expectedErr, err)
 	}
 }
+
+func TestMessageIgnoreTemplatePluralFormMissing(t *testing.T) {
+	mt := NewMessageTemplate(&Message{ID: "HelloWorld", Other: "Hello World"})
+	s, err := mt.Get(plural.Few)
+	if s != "" {
+		t.Errorf("expected %q; got %q", "", s)
+	}
+	expectedErr := pluralFormNotFoundError{pluralForm: plural.Few, messageID: "HelloWorld"}
+	if !reflect.DeepEqual(err, expectedErr) {
+		t.Errorf("expected error %#v; got %#v", expectedErr, err)
+	}
+}


### PR DESCRIPTION
Hi,

I use your library in production and it works great. Except now I've come to a point where I need it to play nicely with a different string parameter syntax.

Just for context, I'm dealing with a shared repository of localized strings which has multiple consumers using different programming languages and libraries. This already involves conversion from xliff to a format suitable for go-i18n and some of the strings contain placeholders with a C#-like (but simplified) format string syntax (e.g. `"arg1: {0}, arg2: {1}, {{escaped}}"`).

The problem is with escaped curly braces which correspond to parameters in go templates. When I try to localize a string like this, I get en error because it's not even a valid go template.

Therefore it would be very useful if I could just disable template execution and process any string parameters with custom syntax myself.