### PR TITLE
Add context awareness

### DIFF
--- a/i18n/context.go
+++ b/i18n/context.go
@@ -6,11 +6,11 @@ type contextKeyType struct{}
 
 var contextKey = contextKeyType{}
 
-// LocalizerFromContext raises request-scoped localizer.
-// Warning: localizer will be <nil> if it was not set
-// using [ContextWithLocalizer].
-func LocalizerFromContext(ctx context.Context) *Localizer {
-	return ctx.Value(contextKey).(*Localizer)
+// LocalizerFromContext raises request-scoped localizer from context.
+// Returns `<nil>, false` if there is no localizer in context.
+func LocalizerFromContext(ctx context.Context) (l *Localizer, ok bool) {
+	l, ok = ctx.Value(contextKey).(*Localizer)
+	return
 }
 
 // ContextWithLocalizer adds localizer into context as a value.

--- a/i18n/context.go
+++ b/i18n/context.go
@@ -1,0 +1,20 @@
+package i18n
+
+import "context"
+
+type contextKeyType struct{}
+
+var contextKey = contextKeyType{}
+
+// LocalizerFromContext raises request-scoped localizer.
+// Warning: localizer will be <nil> if it was not set
+// using [ContextWithLocalizer].
+func LocalizerFromContext(ctx context.Context) *Localizer {
+	return ctx.Value(contextKey).(*Localizer)
+}
+
+// ContextWithLocalizer adds localizer into context as a value.
+// Use [LocalizerFromContext] to recover it later.
+func ContextWithLocalizer(parent context.Context, l *Localizer) context.Context {
+	return context.WithValue(parent, contextKey, l)
+}

--- a/i18n/context_test.go
+++ b/i18n/context_test.go
@@ -1,0 +1,25 @@
+package i18n
+
+import (
+	"context"
+	"testing"
+
+	"golang.org/x/text/language"
+)
+
+func TestContextAwareness(t *testing.T) {
+	bundle := NewBundle(language.English)
+	localizer := NewLocalizer(bundle, "en")
+	ctx := ContextWithLocalizer(context.Background(), localizer)
+	if ctx == nil {
+		t.Error("<nil> context")
+	}
+
+	recovered, ok := LocalizerFromContext(ctx)
+	if !ok {
+		t.Error("localizer was not recovered")
+	}
+	if recovered == nil {
+		t.Error("recovered a <nil> localizer from context")
+	}
+}


### PR DESCRIPTION
It is expected for Golang APIs to be context-aware by default. I assume many projects are relying on context to pass a localizer down the call stack as I am doing. It makes sense to scope the context key to the same package.

I added two functions:

- ContextWithLocalizer to insert
- LocalizerFromContext to recover