### PR TITLE
Adds ability to extract strings from T() functions to `goi18n extract`

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,4 +1,4 @@
-# Example
+# Web Example
 
 This directory contains an example project that uses go-i18n.
 
@@ -11,3 +11,36 @@ Then open http://localhost:8080 in your web browser.
 You can customize the template data and locale via query parameters like this:
 http://localhost:8080/?name=Nick&unreadEmailCount=2
 http://localhost:8080/?name=Nick&unreadEmailCount=2&lang=es
+
+
+# CLI Example
+
+This CLI example shows how to use a `T()` function to translate simple strings in a compiled CLI application.
+
+The [go-locale](github.com/Xuanwo/go-locale) library is used to detect the users preferred language.
+The [cobra](github.com/spf13/cobr) library is used to setup the CLI itself.
+the [embed](https://pkg.go.dev/embed) library is used to compile the translation json files into the CLI binary.
+These libraries may need to be installed specifically to compile this cli application if needed.
+
+```bash
+go get github.com/spf13/cobra
+go get github.com/Xuanwo/go-locale
+```
+
+To run the example for a given language, you can do the following:
+```bash
+$> LANGUAGE=en-US go run cli.go
+Detected Locale is en-US
+Hello World!
+
+$> LANGUAGE=es-ES go run cli.go
+La configuración regional detectada es es-ES
+Hola Mundo!
+```
+
+To extract the string from this example:
+>Assumes you are in the `example` directory.
+
+```bash
+goi18n extract -outdir ./ -format json --sourceLanguage en-US ./cli.go
+```

--- a/example/active.en-US.json
+++ b/example/active.en-US.json
@@ -1,0 +1,20 @@
+{
+  "Detected Locale is {{.User_locale}}": {
+    "other": "Detected Locale is {{.User_locale}}"
+  },
+  "ERROR: {{.Error}}": {
+    "other": "ERROR: {{.Error}}"
+  },
+  "Hello World!": {
+    "other": "Hello World!"
+  },
+  "T_Error_Message": {
+    "other": "Translation Error: {{.Error}}"
+  },
+  "This is a longer description.": {
+    "other": "This is a longer description."
+  },
+  "This is an example of how to translate a CLI application": {
+    "other": "This is an example of how to translate a CLI application"
+  }
+}

--- a/example/active.es-ES.json
+++ b/example/active.es-ES.json
@@ -1,0 +1,20 @@
+{
+  "Detected Locale is {{.User_locale}}": {
+    "other": "La configuración regional detectada es {{.User_locale}}"
+  },
+  "ERROR: {{.Error}}": {
+    "other": "ERROR: {{.Error}}"
+  },
+  "Hello World!": {
+    "other": "Hola Mundo!"
+  },
+  "T_Error_Message": {
+    "other": "Error de traducción: {{.Error}}"
+  },
+  "This is a longer description.": {
+    "other": "Esta es una descripción más larga."
+  },
+  "This is an example of how to translate a CLI application": {
+    "other": "Este es un ejemplo de cómo traducir una aplicación CLI."
+  }
+}

--- a/example/cli.go
+++ b/example/cli.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"os"
+	"fmt"
+	"embed"
+	"golang.org/x/text/language"
+	"encoding/json"
+	"github.com/spf13/cobra"
+	"github.com/Xuanwo/go-locale"
+	goi18n "github.com/nicksnyder/go-i18n/v2/i18n"
+)
+
+// This will cause go to embed the translation files into the binary when it is compiled.
+//go:embed active.*.json
+var LocaleFS embed.FS
+
+// Init the localizer
+var localizer = InitLocalizer()
+
+// Sets the localizer with the proper language
+func InitLocalizer() *goi18n.Localizer {
+	locale := DetectLocal()
+	bundle := goi18n.NewBundle(language.English)
+	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
+	lang_file := fmt.Sprintf("active.%s.json", locale)
+	_, err := bundle.LoadMessageFileFS(LocaleFS, lang_file)
+	if err != nil {
+		fmt.Println("Unable to load language from %s", lang_file)
+	}
+
+	loc := goi18n.NewLocalizer(bundle, locale)
+	return loc
+}
+
+// Tries to determine the system locale, when local isn't set, default to en_US
+// Mostly this reads from 'LANGUAGE' ENV variable. https://github.com/Xuanwo/go-locale for other ways to set this.
+func DetectLocal() string {
+	tag, err := locale.Detect()
+	if err != nil {
+		return "en-US"
+	}
+	return tag.String()
+}
+
+// Translates a string, with any substitutions needed. Handles simple cases where plural count is not needed.
+// text: string to be translated
+// subs: A single map[string]interface{} incase the text string needs variable substitutions.
+func T(text string, subs ...interface{}) string {
+
+	config := &goi18n.LocalizeConfig{
+		DefaultMessage: &goi18n.Message{ID: text, Other: text},
+	}
+	// Need to use `subs ...interface{}` so that we can have 0 or 1 subs.
+	if subs != nil && len(subs) == 1 {
+		config.TemplateData = subs[0]
+	}
+
+	// Actually translate the message.
+	l_string, err := localizer.Localize(config)
+
+	// If a string is not in the translation file, print an error.
+	if err != nil {
+		// Can't recursively use the T() function here otherwise you get an infinite loop.
+		error_message := &goi18n.LocalizeConfig{
+			DefaultMessage: &goi18n.Message{
+				ID: "T_Error_Message",
+				Other: "Translation Error: {{.Error}}",
+			},
+		}
+		error_message.TemplateData = map[string]interface{}{
+			"Error": err.Error(),
+		}
+		e_string, _ := localizer.Localize(error_message)
+		fmt.Println(e_string)
+	}
+	return l_string
+}
+
+var rootCmd = &cobra.Command{
+	Use: "cli",
+	Short: T("This is an example of how to translate a CLI application"),
+	Long: T("This is a longer description."),
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(T("Hello World!"))
+	},
+}
+
+func main() {
+	// Just an example of how string substitution can work with T() functions
+	user_locale := DetectLocal()
+	locale_sub := map[string]interface{}{"User_locale": user_locale}
+	fmt.Println(T("Detected Locale is {{.User_locale}}", locale_sub))
+
+	// Actually run the command and handle any errors.
+	if err := rootCmd.Execute(); err != nil {
+		subs := map[string]interface{}{"Error": err.Error()}
+		fmt.Println(T("ERROR: {{.Error}}", subs), err.Error())
+		os.Exit(1)
+	}
+}

--- a/goi18n/extract_command_test.go
+++ b/goi18n/extract_command_test.go
@@ -246,9 +246,25 @@ zero = "Zero translation"
 			activeFile: []byte(`id = "my const"
 `),
 		},
+		{
+			name:     "T Finder",
+			fileName: "file.go",
+			file: `package main
+
+			import "github.com/nicksnyder/go-i18n/v2/i18n"
+
+			func T(i18n string) string {return i18n}
+			var this = T("I18n This String Please")
+			`,
+			activeFile: []byte(`"I18n This String Please" = "I18n This String Please"
+`),
+		},
 	}
 
 	for _, test := range tests {
+		if test.name != "T Finder" {
+			continue
+		}
 		t.Run(test.name, func(t *testing.T) {
 			indir := mustTempDir("TestExtractCommandIn")
 			defer os.RemoveAll(indir)

--- a/goi18n/extract_command_test.go
+++ b/goi18n/extract_command_test.go
@@ -262,9 +262,6 @@ zero = "Zero translation"
 	}
 
 	for _, test := range tests {
-		if test.name != "T Finder" {
-			continue
-		}
 		t.Run(test.name, func(t *testing.T) {
 			indir := mustTempDir("TestExtractCommandIn")
 			defer os.RemoveAll(indir)


### PR DESCRIPTION
### Purpose
`goi18n extract` will now extract strings wrapped in a `T` function, in addition to the other cases it extracts strings from.
I also added an example CLI application to go with the web application that shows how to embed i18n files, and use T wrapper functions for translations.

### Reason
This feature will help people like me migrating from v1 to v2 of this library. V1 encouraged the use of the `T` wrapper, so having a way to easily extract those strings would make my life a lot easier, and I assume others who make the migration as well.


Thanks for your time reviewing this issue, and I'll address any issues you may have with the code.
Also thanks for making this library in the first place.

