### PR TITLE
Extract errors for duplicate message ids

### DIFF
--- a/goi18n/extract_command.go
+++ b/goi18n/extract_command.go
@@ -8,6 +8,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -105,6 +106,9 @@ func (ec *extractCommand) execute() error {
 	messageTemplates := map[string]*i18n.MessageTemplate{}
 	for _, m := range messages {
 		if mt := i18n.NewMessageTemplate(m); mt != nil {
+			if duplicateMessage, ok := messageTemplates[m.ID]; ok && !reflect.DeepEqual(mt, duplicateMessage) {
+				return &duplicateMessageIDErr{messageID: m.ID}
+			}
 			messageTemplates[m.ID] = mt
 		}
 	}
@@ -113,6 +117,14 @@ func (ec *extractCommand) execute() error {
 		return err
 	}
 	return os.WriteFile(path, content, 0666)
+}
+
+type duplicateMessageIDErr struct {
+	messageID string
+}
+
+func (e *duplicateMessageIDErr) Error() string {
+	return fmt.Sprintf("duplicate message ID: %s", e.messageID)
 }
 
 // extractMessages extracts messages from the bytes of a Go source file.


### PR DESCRIPTION
`go-i18n extract` will error if it finds a message ID that has been duplicated but contains different content.

Duplication with the same content is harmless so it will not error in this case to be lenient.

Fixes https://github.com/nicksnyder/go-i18n/issues/332