### PR TITLE
feat(template): add FastParser for TinyGo compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,8 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/text v0.32.0
 )
+
+require (
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasttemplate v1.2.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
+github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=

--- a/i18n/localizer_test.go
+++ b/i18n/localizer_test.go
@@ -385,6 +385,197 @@ func localizerTests() []localizerTest {
 			expectedLocalized: "Hello {{.Person}}",
 		},
 		{
+			name:            "fast parser, bundle message",
+			defaultLanguage: language.English,
+			messages: map[language.Tag][]*Message{
+				language.English: {{
+					ID:    "HelloPerson",
+					Other: "Hello {{.Person}}",
+				}},
+			},
+			acceptLangs: []string{"en"},
+			conf: &LocalizeConfig{
+				MessageID: "HelloPerson",
+				TemplateData: map[string]string{
+					"Person": "Nick",
+				},
+				TemplateParser: &template.FastParser{},
+			},
+			expectedLocalized: "Hello Nick",
+		},
+		{
+			name:            "fast parser, default message with plural",
+			defaultLanguage: language.English,
+			acceptLangs:     []string{"en"},
+			conf: &LocalizeConfig{
+				DefaultMessage: &Message{
+					ID:    "PersonCats",
+					One:   "{{.Person}} has {{.Count}} cat",
+					Other: "{{.Person}} has {{.Count}} cats",
+				},
+				TemplateData: map[string]interface{}{
+					"Person": "Nick",
+					"Count":  2,
+				},
+				PluralCount:    2,
+				TemplateParser: &template.FastParser{},
+			},
+			expectedLocalized: "Nick has 2 cats",
+		},
+		{
+			name:            "fast parser, plural count one",
+			defaultLanguage: language.English,
+			acceptLangs:     []string{"en"},
+			conf: &LocalizeConfig{
+				DefaultMessage: &Message{
+					ID:    "PersonCats",
+					One:   "{{.Person}} has {{.Count}} cat",
+					Other: "{{.Person}} has {{.Count}} cats",
+				},
+				TemplateData: map[string]interface{}{
+					"Person": "Alice",
+					"Count":  1,
+				},
+				PluralCount:    1,
+				TemplateParser: &template.FastParser{},
+			},
+			expectedLocalized: "Alice has 1 cat",
+		},
+		{
+			name:            "fast parser, plural count float",
+			defaultLanguage: language.English,
+			acceptLangs:     []string{"en"},
+			conf: &LocalizeConfig{
+				DefaultMessage: &Message{
+					ID:    "Weight",
+					One:   "{{.Item}} weighs {{.Weight}} kg",
+					Other: "{{.Item}} weighs {{.Weight}} kg",
+				},
+				TemplateData: map[string]interface{}{
+					"Item":   "Apple",
+					"Weight": "1.5",
+				},
+				PluralCount:    "1.5",
+				TemplateParser: &template.FastParser{},
+			},
+			expectedLocalized: "Apple weighs 1.5 kg",
+		},
+		{
+			name:            "fast parser, custom delims",
+			defaultLanguage: language.English,
+			messages: map[language.Tag][]*Message{
+				language.English: {{
+					ID:         "HelloPerson",
+					Other:      "Hello <<.Person>>!",
+					LeftDelim:  "<<",
+					RightDelim: ">>",
+				}},
+			},
+			acceptLangs: []string{"en"},
+			conf: &LocalizeConfig{
+				MessageID: "HelloPerson",
+				TemplateData: map[string]interface{}{
+					"Person": "World",
+				},
+				TemplateParser: &template.FastParser{},
+			},
+			expectedLocalized: "Hello World!",
+		},
+		{
+			name:            "fast parser, missing key keeps placeholder",
+			defaultLanguage: language.English,
+			acceptLangs:     []string{"en"},
+			conf: &LocalizeConfig{
+				DefaultMessage: &Message{
+					ID:    "HelloPerson",
+					Other: "Hello {{.Person}}!",
+				},
+				TemplateData:   map[string]interface{}{},
+				TemplateParser: &template.FastParser{},
+			},
+			expectedLocalized: "Hello {{.Person}}!",
+		},
+		{
+			name:            "fast parser, no placeholders",
+			defaultLanguage: language.English,
+			acceptLangs:     []string{"en"},
+			conf: &LocalizeConfig{
+				DefaultMessage: &Message{
+					ID:    "StaticMessage",
+					Other: "This is a static message",
+				},
+				TemplateParser: &template.FastParser{},
+			},
+			expectedLocalized: "This is a static message",
+		},
+		{
+			name:            "fast parser, PluralCount auto injection",
+			defaultLanguage: language.English,
+			acceptLangs:     []string{"en"},
+			conf: &LocalizeConfig{
+				DefaultMessage: &Message{
+					ID:    "ItemCount",
+					One:   "You have {{.PluralCount}} item",
+					Other: "You have {{.PluralCount}} items",
+				},
+				PluralCount:    5,
+				TemplateParser: &template.FastParser{},
+			},
+			expectedLocalized: "You have 5 items",
+		},
+		{
+			name:            "fast parser, multiple placeholders",
+			defaultLanguage: language.English,
+			acceptLangs:     []string{"en"},
+			conf: &LocalizeConfig{
+				DefaultMessage: &Message{
+					ID:    "OrderInfo",
+					Other: "Order #{{.OrderID}}: {{.Item}} x{{.Quantity}} = ${{.Total}}",
+				},
+				TemplateData: map[string]interface{}{
+					"OrderID":  12345,
+					"Item":     "Widget",
+					"Quantity": 3,
+					"Total":    "29.97",
+				},
+				TemplateParser: &template.FastParser{},
+			},
+			expectedLocalized: "Order #12345: Widget x3 = $29.97",
+		},
+		{
+			name:            "fast parser, map[string]string data",
+			defaultLanguage: language.English,
+			acceptLangs:     []string{"en"},
+			conf: &LocalizeConfig{
+				DefaultMessage: &Message{
+					ID:    "UserGreeting",
+					Other: "Welcome, {{.Username}}! Your role is {{.Role}}.",
+				},
+				TemplateData: map[string]string{
+					"Username": "john_doe",
+					"Role":     "admin",
+				},
+				TemplateParser: &template.FastParser{},
+			},
+			expectedLocalized: "Welcome, john_doe! Your role is admin.",
+		},
+		{
+			name:            "fast parser, without dot prefix",
+			defaultLanguage: language.English,
+			acceptLangs:     []string{"en"},
+			conf: &LocalizeConfig{
+				DefaultMessage: &Message{
+					ID:    "HelloPerson",
+					Other: "Hello {{Name}}!",
+				},
+				TemplateData: map[string]interface{}{
+					"Name": "TinyGo",
+				},
+				TemplateParser: &template.FastParser{},
+			},
+			expectedLocalized: "Hello TinyGo!",
+		},
+		{
 			name:            "identity parser, default message",
 			defaultLanguage: language.English,
 			acceptLangs:     []string{"en"},

--- a/i18n/template/fast_parser.go
+++ b/i18n/template/fast_parser.go
@@ -1,0 +1,200 @@
+package template
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/valyala/fasttemplate"
+)
+
+// FastParser is a Parser that uses valyala/fasttemplate for simple placeholder substitution.
+//
+// This parser was introduced primarily for TinyGo compatibility. TinyGo has limited support
+// for the standard library's text/template and html/template packages due to their heavy use
+// of reflection and other features that are difficult to compile to WebAssembly or embedded
+// targets. FastParser provides a lightweight alternative that works reliably in TinyGo
+// environments while still supporting the common use case of simple placeholder substitution.
+//
+// FastParser is also faster than TextParser for templates that only use simple {{.Key}}
+// placeholders without any functions or complex template logic.
+//
+// Supported syntax:
+//   - {{.Key}} - dot-prefixed placeholder (standard go-i18n style)
+//   - {{Key}} - direct key reference
+//
+// Limitations (use TextParser for these features):
+//   - Template functions (e.g., {{printf "%s" .Name}})
+//   - Conditionals (e.g., {{if .Cond}}...{{end}})
+//   - Range loops (e.g., {{range .Items}}...{{end}})
+//   - Nested field access (e.g., {{.User.Name}})
+//   - Method calls (e.g., {{.Name.String}})
+type FastParser struct {
+	LeftDelim  string
+	RightDelim string
+}
+
+func (fp *FastParser) Cacheable() bool {
+	return true
+}
+
+func (fp *FastParser) Parse(src, leftDelim, rightDelim string) (ParsedTemplate, error) {
+	if leftDelim == "" {
+		leftDelim = fp.LeftDelim
+	}
+	if leftDelim == "" {
+		leftDelim = "{{"
+	}
+
+	if !strings.Contains(src, leftDelim) {
+		return &identityParsedTemplate{src: src}, nil
+	}
+
+	if rightDelim == "" {
+		rightDelim = fp.RightDelim
+	}
+	if rightDelim == "" {
+		rightDelim = "}}"
+	}
+
+	tmpl, err := fasttemplate.NewTemplate(src, leftDelim, rightDelim)
+	if err != nil {
+		return nil, err
+	}
+
+	return &parsedFastTemplate{
+		tmpl:       tmpl,
+		leftDelim:  leftDelim,
+		rightDelim: rightDelim,
+	}, nil
+}
+
+type parsedFastTemplate struct {
+	tmpl       *fasttemplate.Template
+	leftDelim  string
+	rightDelim string
+}
+
+func (t *parsedFastTemplate) Execute(data any) (string, error) {
+	m := toTagFuncMap(data)
+	return t.tmpl.ExecuteFuncString(func(w io.Writer, tag string) (int, error) {
+		if fn, ok := m[tag]; ok {
+			return fn(w, tag)
+		}
+		return w.Write([]byte(t.leftDelim + tag + t.rightDelim))
+	}), nil
+}
+
+type tagFunc = func(w io.Writer, tag string) (int, error)
+
+func toTagFuncMap(data any) map[string]tagFunc {
+	if data == nil {
+		return map[string]tagFunc{}
+	}
+
+	switch d := data.(type) {
+	case map[string]interface{}:
+		return mapToTagFuncs(d)
+	case map[string]string:
+		m := make(map[string]tagFunc, len(d)*2)
+		for k, v := range d {
+			val := v
+			fn := func(w io.Writer, _ string) (int, error) {
+				return w.Write([]byte(val))
+			}
+			m[k] = fn
+			m["."+k] = fn
+		}
+		return m
+	default:
+		return structToTagFuncs(data)
+	}
+}
+
+func mapToTagFuncs(m map[string]interface{}) map[string]tagFunc {
+	result := make(map[string]tagFunc, len(m)*2)
+	for k, v := range m {
+		fn := valueToTagFunc(v)
+		result[k] = fn
+		if !strings.HasPrefix(k, ".") {
+			result["."+k] = fn
+		}
+	}
+	return result
+}
+
+func valueToTagFunc(v interface{}) tagFunc {
+	switch val := v.(type) {
+	case string:
+		return func(w io.Writer, _ string) (int, error) {
+			return w.Write([]byte(val))
+		}
+	case []byte:
+		return func(w io.Writer, _ string) (int, error) {
+			return w.Write(val)
+		}
+	case fmt.Stringer:
+		s := val.String()
+		return func(w io.Writer, _ string) (int, error) {
+			return w.Write([]byte(s))
+		}
+	default:
+		s := fmt.Sprint(v)
+		return func(w io.Writer, _ string) (int, error) {
+			return w.Write([]byte(s))
+		}
+	}
+}
+
+func structToTagFuncs(data any) map[string]tagFunc {
+	if data == nil {
+		return map[string]tagFunc{}
+	}
+
+	if s, ok := data.(fmt.Stringer); ok {
+		str := s.String()
+		fn := func(w io.Writer, _ string) (int, error) {
+			return w.Write([]byte(str))
+		}
+		return map[string]tagFunc{"": fn, ".": fn}
+	}
+
+	return reflectStructToTagFuncs(data)
+}
+
+func reflectStructToTagFuncs(data any) map[string]tagFunc {
+	if data == nil {
+		return map[string]tagFunc{}
+	}
+
+	val := reflect.ValueOf(data)
+	for val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return map[string]tagFunc{}
+		}
+		val = val.Elem()
+	}
+
+	if val.Kind() != reflect.Struct {
+		return map[string]tagFunc{}
+	}
+
+	typ := val.Type()
+	m := make(map[string]tagFunc, val.NumField()*2)
+
+	for i := 0; i < val.NumField(); i++ {
+		field := typ.Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+		fieldVal := val.Field(i)
+		if fieldVal.CanInterface() {
+			fn := valueToTagFunc(fieldVal.Interface())
+			m[field.Name] = fn
+			m["."+field.Name] = fn
+		}
+	}
+
+	return m
+}

--- a/i18n/template/fast_parser_test.go
+++ b/i18n/template/fast_parser_test.go
@@ -1,0 +1,207 @@
+package template
+
+import (
+	"testing"
+)
+
+func TestFastParser_Cacheable(t *testing.T) {
+	fp := &FastParser{}
+	if !fp.Cacheable() {
+		t.Error("FastParser should always be cacheable")
+	}
+}
+
+func TestFastParser_Parse(t *testing.T) {
+	tests := []struct {
+		name       string
+		src        string
+		leftDelim  string
+		rightDelim string
+		data       any
+		want       string
+		wantErr    bool
+	}{
+		{
+			name: "simple substitution with dot prefix",
+			src:  "Hello {{.Name}}!",
+			data: map[string]interface{}{"Name": "World"},
+			want: "Hello World!",
+		},
+		{
+			name: "simple substitution without dot prefix",
+			src:  "Hello {{Name}}!",
+			data: map[string]interface{}{"Name": "World"},
+			want: "Hello World!",
+		},
+		{
+			name: "multiple placeholders",
+			src:  "{{.Greeting}}, {{.Name}}!",
+			data: map[string]interface{}{"Greeting": "Hello", "Name": "World"},
+			want: "Hello, World!",
+		},
+		{
+			name: "no placeholders",
+			src:  "Hello World!",
+			data: map[string]interface{}{"Name": "Ignored"},
+			want: "Hello World!",
+		},
+		{
+			name: "nil data",
+			src:  "Hello World!",
+			data: nil,
+			want: "Hello World!",
+		},
+		{
+			name: "missing key keeps placeholder",
+			src:  "Hello {{.Name}}!",
+			data: map[string]interface{}{},
+			want: "Hello {{.Name}}!",
+		},
+		{
+			name:       "custom delimiters",
+			src:        "Hello <<.Name>>!",
+			leftDelim:  "<<",
+			rightDelim: ">>",
+			data:       map[string]interface{}{"Name": "World"},
+			want:       "Hello World!",
+		},
+		{
+			name: "map[string]string data",
+			src:  "Hello {{.Name}}!",
+			data: map[string]string{"Name": "World"},
+			want: "Hello World!",
+		},
+		{
+			name: "integer value",
+			src:  "Count: {{.Count}}",
+			data: map[string]interface{}{"Count": 42},
+			want: "Count: 42",
+		},
+		{
+			name: "plural count style",
+			src:  "You have {{.PluralCount}} items",
+			data: map[string]interface{}{"PluralCount": 5},
+			want: "You have 5 items",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fp := &FastParser{}
+			parsed, err := fp.Parse(tt.src, tt.leftDelim, tt.rightDelim)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+
+			got, err := parsed.Execute(tt.data)
+			if err != nil {
+				t.Errorf("Execute() error = %v", err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Execute() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFastParser_ParseError(t *testing.T) {
+	fp := &FastParser{}
+	_, err := fp.Parse("Hello {{Name", "", "")
+	if err == nil {
+		t.Error("expected error for unclosed tag")
+	}
+}
+
+func TestFastParser_StructData(t *testing.T) {
+	type Person struct {
+		Name string
+		Age  int
+	}
+
+	fp := &FastParser{}
+	parsed, err := fp.Parse("{{.Name}} is {{.Age}} years old", "", "")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	got, err := parsed.Execute(Person{Name: "Alice", Age: 30})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	want := "Alice is 30 years old"
+	if got != want {
+		t.Errorf("Execute() = %q, want %q", got, want)
+	}
+}
+
+func TestFastParser_PointerStructData(t *testing.T) {
+	type Person struct {
+		Name string
+	}
+
+	fp := &FastParser{}
+	parsed, err := fp.Parse("Hello {{.Name}}", "", "")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	got, err := parsed.Execute(&Person{Name: "Bob"})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	want := "Hello Bob"
+	if got != want {
+		t.Errorf("Execute() = %q, want %q", got, want)
+	}
+}
+
+func TestFastParser_ParserDelims(t *testing.T) {
+	fp := &FastParser{
+		LeftDelim:  "[[",
+		RightDelim: "]]",
+	}
+
+	parsed, err := fp.Parse("Hello [[.Name]]!", "", "")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	got, err := parsed.Execute(map[string]interface{}{"Name": "World"})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	want := "Hello World!"
+	if got != want {
+		t.Errorf("Execute() = %q, want %q", got, want)
+	}
+}
+
+func BenchmarkFastParser_Execute(b *testing.B) {
+	fp := &FastParser{}
+	parsed, _ := fp.Parse("Hello {{.Name}}, you have {{.Count}} messages", "", "")
+	data := map[string]interface{}{"Name": "User", "Count": 42}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = parsed.Execute(data)
+	}
+}
+
+func BenchmarkTextParser_Execute(b *testing.B) {
+	tp := &TextParser{}
+	parsed, _ := tp.Parse("Hello {{.Name}}, you have {{.Count}} messages", "", "")
+	data := map[string]interface{}{"Name": "User", "Count": 42}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = parsed.Execute(data)
+	}
+}


### PR DESCRIPTION
## Summary

Add `FastParser` as an alternative template parser using [valyala/fasttemplate](https://github.com/valyala/fasttemplate), primarily for **TinyGo compatibility**.

## Motivation

TinyGo has limited support for the standard library's `text/template` and `html/template` packages due to their heavy use of reflection and other features that are difficult to compile to WebAssembly or embedded targets. This makes go-i18n unusable in TinyGo environments when templates contain placeholders.

`FastParser` provides a lightweight alternative that works reliably in TinyGo while still supporting the common use case of simple placeholder substitution.

## Changes

- Add `FastParser` implementing `template.Parser` interface
- Add comprehensive unit tests for `FastParser`
- Add integration tests in `localizer_test.go`
- Add `github.com/valyala/fasttemplate` dependency

## Usage

```go
localizer.Localize(&i18n.LocalizeConfig{
    DefaultMessage: &i18n.Message{
        ID:    "HelloPerson",
        One:   "{{.Name}} has {{.Count}} cat",
        Other: "{{.Name}} has {{.Count}} cats",
    },
    TemplateData: map[string]interface{}{
        "Name":  "Nick",
        "Count": 2,
    },
    PluralCount:    2,
    TemplateParser: &template.FastParser{},  // Use FastParser
})
```

## Supported Features

- Simple placeholder substitution: `{{.Key}}` and `{{Key}}`
- Custom delimiters (e.g., `<<` `>>`)
- Data types: `map[string]interface{}`, `map[string]string`, and structs
- All plural forms (Zero, One, Two, Few, Many, Other)
- Missing keys preserve the original placeholder

## Limitations

For these features, continue using `TextParser`:
- Template functions (e.g., `{{printf "%s" .Name}}`)
- Conditionals (e.g., `{{if .Cond}}...{{end}}`)
- Range loops (e.g., `{{range .Items}}...{{end}}`)
- Nested field access (e.g., `{{.User.Name}}`)
- Method calls (e.g., `{{.Name.String}}`)

## Benchmark

```
BenchmarkFastParser_Execute-14    249.3 ns/op    368 B/op    10 allocs/op
BenchmarkTextParser_Execute-14    263.1 ns/op    336 B/op     9 allocs/op
```

FastParser is slightly faster (~5%) for simple placeholder substitution.